### PR TITLE
Problem: capnp files are compiled twice.

### DIFF
--- a/build-support/buildFractalideComponent.nix
+++ b/build-support/buildFractalideComponent.nix
@@ -90,8 +90,7 @@ in stdenv.mkDerivation (args // {
   buildPhase = args.buildPhase or ''
     ${stdenv.lib.concatMapStringsSep "\n"
     (pkg: "
-      cp ${pkg.outPath}/src/*.capnp src/${pkg.name}.capnp;
-      ${capnproto}/bin/capnp compile -o${capnpc-rust}/bin/capnpc-rust:src/  src/*.capnp")
+      cp ${pkg.outPath}/src/*.rs src/${pkg.name}.rs;")
     (stdenv.lib.flatten contracts)}
     echo "Running cargo build --release"
     cargo build --release

--- a/components/maths/boolean/nand/src/lib.rs
+++ b/components/maths/boolean/nand/src/lib.rs
@@ -34,7 +34,7 @@ component! {
   }
 
   mod maths_boolean {
-    include!("maths_boolean_capnp.rs");
+    include!("maths-boolean.rs");
   }
   use self::maths_boolean::boolean;
 }

--- a/components/maths/number/add/src/lib.rs
+++ b/components/maths/number/add/src/lib.rs
@@ -35,7 +35,7 @@ component! {
   }
 
   mod maths_number {
-    include!("maths_number_capnp.rs");
+    include!("maths-number.rs");
   }
   use self::maths_number::number;
 }


### PR DESCRIPTION
Solution: copy compiled capnp rust file from /nix/store/
to the component tmp compilation folder. This should
save time when building components.
