### PR TITLE
Problem: component artifact names are different

### DIFF
--- a/build-support/buildFractalideComponent.nix
+++ b/build-support/buildFractalideComponent.nix
@@ -88,6 +88,7 @@ in stdenv.mkDerivation (args // {
   '' + (args.prePatch or "");
 
   buildPhase = args.buildPhase or ''
+    sed -i "s/name = .*/name = \"component\"/g" Cargo.toml
     ${stdenv.lib.concatMapStringsSep "\n"
     (pkg: "
       cp ${pkg.outPath}/src/*.rs src/${pkg.name}.rs;")


### PR DESCRIPTION
Solution: the folder naming is enough to determine
the correct library. So to make it easier on the
fvm so as not to have to calculate the name it wants
we make the component dynamic library names the same.

i.e. /nix/store/<hash>-<component-name>/lib/libcomponent.so
