### PR TITLE
Problem : IIP only for boolean

### DIFF
--- a/build-support/component_lookup/Cargo.lock
+++ b/build-support/component_lookup/Cargo.lock
@@ -2,7 +2,7 @@
 name = "component_lookup"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/build-support/component_lookup/default.nix
+++ b/build-support/component_lookup/default.nix
@@ -4,7 +4,7 @@ buildFractalideComponent rec {
   name = "component_lookup";
   src = ./.;
   filteredContracts = filterContracts ["path" "option_path"];
-  depsSha256 = "154zm5j4kds42179i7z028ix2cn39x75b0j4v4n8v9y2rrqkq2bg";
+  depsSha256 = "0bcv27wqi1lgvh15yw0hf0q73wmm9df0nzb6spyxfin1j2gvsf94";
   configurePhase = ''
 substituteInPlace src/lib.rs --replace "nix-replace-me" "${stdenv.lib.concatMapStringsSep "\n"
 (pkg: ''\"${pkg.name}\" => { Some (\"${(stdenv.lib.last (stdenv.lib.splitString "/" pkg.outPath))}\")},'')

--- a/build-support/contract_lookup/Cargo.lock
+++ b/build-support/contract_lookup/Cargo.lock
@@ -2,7 +2,7 @@
 name = "contract_lookup"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/build-support/contract_lookup/default.nix
+++ b/build-support/contract_lookup/default.nix
@@ -4,7 +4,7 @@ buildFractalideComponent rec {
   name = "contract_lookup";
   src = ./.;
   filteredContracts = filterContracts ["path" "option_path"];
-  depsSha256 = "1grjh1dbm7gnqma6ksfa5nfajw7mrqkzyczrabhx7ml7vffkbap3";
+  depsSha256 = "0fa1z6z5w2d4aj1c4kvapd1x1ddcjdliig788sx2831rf0kjhm3k";
   configurePhase = ''
 substituteInPlace src/lib.rs --replace "nix-replace-me" "${stdenv.lib.concatMapStringsSep "\n"
 (pkg: ''\"${pkg.name}\" => { Some (\"${(stdenv.lib.last (stdenv.lib.splitString "/" pkg.outPath))}\")},'')

--- a/build-support/rust-packages.nix
+++ b/build-support/rust-packages.nix
@@ -7,15 +7,15 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-version = "2016-01-29";
-rev = "79fbad107da40272e08f7d00459512e1c8c73418";
+version = "2016-02-05";
+rev = "84afc44ce8b2eeb6ee08e1ba61cf0048a9136998";
 
 src = fetchFromGitHub {
   inherit rev;
 
   owner = "rust-lang";
   repo = "crates.io-index";
-  sha256 = "1yqm7hyyw3jskq67iw7lgvsx6494daprizc60lkmvnzh0ib9sh7r";
+  sha256 = "12arwrwsk0b51p4yz7vi93fgbsah14yiw252xdsi2k205cakmddv";
 };
 
 in

--- a/components/default.nix
+++ b/components/default.nix
@@ -4,6 +4,7 @@ callPackage = pkgs.lib.callPackageWith (pkgs // support);
 in
 # insert in alphabetical order to reduce conflicts
 rec {
+  development_capnp_encode = callPackage ./development/capnp/encode {};
   development_fbp_errors = callPackage ./development/fbp/errors {};
   development_fbp_fvm = callPackage ./development/fbp/fvm {};
   development_fbp_parser_lexical = callPackage ./development/fbp/parser/lexical {};

--- a/components/development/capnp/encode/Cargo.lock
+++ b/components/development/capnp/encode/Cargo.lock
@@ -1,0 +1,73 @@
+[root]
+name = "errors"
+version = "0.1.0"
+dependencies = [
+ "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "byteorder"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "capnp"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "capnpc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libloading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustfbp"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+

--- a/components/development/capnp/encode/Cargo.toml
+++ b/components/development/capnp/encode/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "encode"
+version = "0.1.0"
+authors = ["test <test@test.com>"]
+
+[lib]
+name = "encode"
+crate-type = ["dylib"]
+
+[dependencies]
+capnp = "*"
+rustfbp = "*"

--- a/components/development/capnp/encode/default.nix
+++ b/components/development/capnp/encode/default.nix
@@ -1,0 +1,15 @@
+{ stdenv, buildFractalideComponent, filterContracts, genName, upkeepers, ...}:
+
+buildFractalideComponent rec {
+  name = genName ./.;
+  src = ./.;
+  filteredContracts = filterContracts ["generic_text" "path"];
+  depsSha256 = "1g35gpls317czczzv2xa5plbzvn9809i5xvx53r46qd87pq94yvx";
+
+  meta = with stdenv.lib; {
+    description = "Component: Fractalide Virtual Machine";
+    homepage = https://github.com/fractalide/fractalide/tree/master/components/development/fvm;
+    license = with licenses; [ mpl20 ];
+    maintainers = with upkeepers; [ dmichiels ];
+  };
+}

--- a/components/development/capnp/encode/src/lib.rs
+++ b/components/development/capnp/encode/src/lib.rs
@@ -1,0 +1,72 @@
+#[macro_use]
+extern crate rustfbp;
+extern crate capnp;
+
+use std::fs;
+
+mod contract_capnp {
+    include!("path.rs");
+    include!("generic_text.rs");
+}
+use contract_capnp::path;
+use contract_capnp::generic_text;
+
+use std::process::Command;
+use std::process;
+use std::path::Path;
+use std::env;
+
+component! {
+    fvm,
+    inputs(path: path, contract: generic_text, input: generic_text),
+    inputs_array(),
+    outputs(output: any),
+    outputs_array(),
+    option(),
+    acc(),
+    fn run(&mut self) -> Result<()>{
+
+        let path_ip = try!(self.ports.recv("path"));
+        let path = try!(path_ip.get_reader());
+        let path: path::Reader = try!(path.get_root());
+        let path = try!(path.get_path());
+
+        let contract_ip = try!(self.ports.recv("contract"));
+        let contract = try!(contract_ip.get_reader());
+        let contract: generic_text::Reader = try!(contract.get_root());
+        let f_contract = try!(contract.get_text());
+
+        let input_ip = try!(self.ports.recv("input"));
+        let input = try!(input_ip.get_reader());
+        let input: generic_text::Reader = try!(input.get_root());
+        let input = try!(input.get_text());
+
+        let pstr = env::current_exe().unwrap();
+        let parent_dir = Path::new(&pstr).parent();
+        let capnp_path = try!(parent_dir.and_then(|s| s.to_str()).map(|s| {format!("{}/../bootstrap/capnp", s)}).ok_or(result::Error::Misc("cannot create capnp path".into())));
+
+        let mut child = try!(Command::new(capnp_path)
+            .arg("encode")
+            .arg(path)
+            .arg(f_contract)
+            .stdin(process::Stdio::piped())
+            .stdout(process::Stdio::piped())
+            .spawn()
+            );
+
+        if let Some(ref mut stdin) = child.stdin {
+            try!(stdin.write_all(input.as_bytes()));
+        } else {
+            unreachable!();
+        }
+        let output = try!(child.wait_with_output());
+
+        if !output.status.success() {
+            return Err(result::Error::Misc("capnp encode command doesn't work".into()));
+        }
+
+        let send_ip = IP { vec : output.stdout };
+        let _ = self.ports.send("output", send_ip);
+        Ok(())
+    }
+}

--- a/components/development/fbp/errors/Cargo.lock
+++ b/components/development/fbp/errors/Cargo.lock
@@ -2,7 +2,7 @@
 name = "errors"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/development/fbp/errors/default.nix
+++ b/components/development/fbp/errors/default.nix
@@ -4,7 +4,7 @@ buildFractalideComponent rec {
   name = genName ./.;
   src = ./.;
   filteredContracts = filterContracts ["fbp_graph" "fbp_semantic_error" "file_error"];
-  depsSha256 = "1fqnwvizn11lskl090a48y247f8mqrd7w7q2hfhpfh68dd3b37fi";
+  depsSha256 = "1ikznihkz94gwpld7yvpkisq9f72b87hplkf5bmrbbxjr2anscwa";
 
   meta = with stdenv.lib; {
     description = "Component: Fractalide Virtual Machine";

--- a/components/development/fbp/errors/src/lib.rs
+++ b/components/development/fbp/errors/src/lib.rs
@@ -10,15 +10,15 @@ mod contract_capnp {
     include!("fbp_semantic_error.rs");
     include!("file_error.rs");
 }
-use contract_capnp::graph;
+use contract_capnp::fbp_graph;
 use contract_capnp::file_error;
-use contract_capnp::semantic_error;
+use contract_capnp::fbp_semantic_error;
 
 component! {
     fvm,
-    inputs(file_error: file_error, semantic_error: semantic_error),
+    inputs(file_error: file_error, semantic_error: fbp_semantic_error),
     inputs_array(),
-    outputs(output: graph),
+    outputs(output: fbp_graph),
     outputs_array(),
     option(),
     acc(),
@@ -27,7 +27,7 @@ component! {
         match self.ports.try_recv("semantic_error") {
             Ok(mut ip) => {
                 let error = try!(ip.get_reader());
-                let error: semantic_error::Reader = try!(error.get_root());
+                let error: fbp_semantic_error::Reader = try!(error.get_root());
 
                 println!("Graph at : {}", try!(error.get_path()));
                 let parsing = try!(error.get_parsing());
@@ -51,7 +51,7 @@ component! {
 
         let mut new_ip = capnp::message::Builder::new_default();
         {
-            let mut ip = new_ip.init_root::<graph::Builder>();
+            let mut ip = new_ip.init_root::<fbp_graph::Builder>();
             ip.set_path("error");
         }
         let mut send_ip = IP::new();

--- a/components/development/fbp/fvm/Cargo.lock
+++ b/components/development/fbp/fvm/Cargo.lock
@@ -2,7 +2,7 @@
 name = "fvm"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/development/fbp/fvm/default.nix
+++ b/components/development/fbp/fvm/default.nix
@@ -3,8 +3,8 @@
 buildFractalideComponent rec {
   name = genName ./.;
   src = ./.;
-  filteredContracts = filterContracts ["fbp_graph" "fbp_fvm_option" "path" "option_path"];
-  depsSha256 = "0w8b6mldsxqn807sb232m2xb7d9vzlyh5f8rqm6vf5555by3fzw7";
+  filteredContracts = filterContracts ["fbp_graph" "path" "option_path"];
+  depsSha256 = "13f0fyjc9hphzqxh21qr7lcdjv1s617g3ccgxs5l17bgjg5z887l";
 
   meta = with stdenv.lib; {
     description = "Component: Fractalide Virtual Machine";

--- a/components/development/fbp/fvm/src/lib.rs
+++ b/components/development/fbp/fvm/src/lib.rs
@@ -12,7 +12,7 @@ mod contract_capnp {
 }
 use contract_capnp::path;
 use contract_capnp::option_path;
-use contract_capnp::graph;
+use contract_capnp::fbp_graph;
 
 #[derive(Debug)]
 struct Graph {
@@ -26,9 +26,9 @@ struct Graph {
 
 component! {
     fvm,
-    inputs(input: graph, new_path: option_path, error: any),
+    inputs(input: fbp_graph, new_path: option_path, error: any),
     inputs_array(),
-    outputs(output: graph, ask_graph: text, ask_path: path),
+    outputs(output: fbp_graph, ask_graph: path, ask_path: path),
     outputs_array(),
     option(),
     acc(),
@@ -41,7 +41,7 @@ component! {
         // retrieve the asked graph
         let mut ip = try!(self.ports.recv("input"));
         let i_graph = try!(ip.get_reader());
-        let i_graph: graph::Reader = try!(i_graph.get_root());
+        let i_graph: fbp_graph::Reader = try!(i_graph.get_root());
 
         try!(add_graph(self, &mut graph, i_graph, ""));
 
@@ -52,7 +52,7 @@ component! {
     }
 }
 
-fn add_graph(component: &fvm, mut graph: &mut Graph, new_graph: graph::Reader, name: &str) -> Result<()> {
+fn add_graph(component: &fvm, mut graph: &mut Graph, new_graph: fbp_graph::Reader, name: &str) -> Result<()> {
 
     if try!(new_graph.get_path()) == "error" { graph.errors = true; }
 
@@ -153,7 +153,7 @@ fn add_graph(component: &fvm, mut graph: &mut Graph, new_graph: graph::Reader, n
             // retrieve the asked graph
             let mut ip = try!(component.ports.recv("input"));
             let i_graph = try!(ip.get_reader());
-            let i_graph: graph::Reader = try!(i_graph.get_root());
+            let i_graph: fbp_graph::Reader = try!(i_graph.get_root());
 
             add_graph(component, &mut graph, i_graph, &format!("{}-{}", name, c_name));
         } else {
@@ -166,7 +166,7 @@ fn add_graph(component: &fvm, mut graph: &mut Graph, new_graph: graph::Reader, n
 fn send_graph(comp: &fvm, graph: &Graph) -> Result<()> {
     let mut new_ip = capnp::message::Builder::new_default();
     {
-        let mut ip = new_ip.init_root::<graph::Builder>();
+        let mut ip = new_ip.init_root::<fbp_graph::Builder>();
         ip.set_path("");
         {
             let mut nodes = ip.borrow().init_nodes(graph.nodes.len() as u32);

--- a/components/development/fbp/parser/lexical/Cargo.lock
+++ b/components/development/fbp/parser/lexical/Cargo.lock
@@ -2,7 +2,7 @@
 name = "fbp_lexical"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -14,7 +14,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -25,7 +25,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -62,7 +62,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/development/fbp/parser/lexical/default.nix
+++ b/components/development/fbp/parser/lexical/default.nix
@@ -4,7 +4,7 @@ buildFractalideComponent rec {
   name = genName ./.;
   src = ./.;
   filteredContracts = filterContracts ["file" "fbp_lexical"];
-  depsSha256 = "0nq5hxw48iwn834nb28g85b21hxr0wg38k0fbmsvk7h33qh0k0z5";
+  depsSha256 = "1m8ms16188976w93hcd3gw2vmw2m9nh522ywdjc6p2861xv0w9kw";
 
   meta = with stdenv.lib; {
     description = "Component: Flow-based programming lexical parser";

--- a/components/development/fbp/parser/lexical/src/lib.rs
+++ b/components/development/fbp/parser/lexical/src/lib.rs
@@ -11,7 +11,7 @@ mod contract_capnp {
     include!("fbp_lexical.rs");
 }
 use contract_capnp::file;
-use contract_capnp::lexical;
+use contract_capnp::fbp_lexical;
 
 #[derive(Debug)]
 enum Literal {
@@ -99,7 +99,7 @@ named!(comp_or_port<&[u8], Literal>, chain!(
 named!(literal<&[u8], Literal>, alt!(comment | iip | bind | external | comp_or_port));
 
 component! {
-    fbp_lexical,
+    comp,
     inputs(input: file),
     inputs_array(),
     outputs(output: fbp_lexical),
@@ -118,7 +118,7 @@ component! {
                 let path = try!(path);
                 let mut new_ip = capnp::message::Builder::new_default();
                 {
-                    let mut ip = new_ip.init_root::<lexical::Builder>();
+                    let mut ip = new_ip.init_root::<fbp_lexical::Builder>();
                     ip.set_start(&path);
                 }
                 let mut send_ip = IP::new();
@@ -133,7 +133,7 @@ component! {
     }
 }
 
-fn handle_stream(comp: &fbp_lexical) -> Result<()> {
+fn handle_stream(comp: &comp) -> Result<()> {
     loop {
         // Get one IP
         let mut ip = try!(comp.ports.recv("input"));
@@ -149,7 +149,7 @@ fn handle_stream(comp: &fbp_lexical) -> Result<()> {
                     match literal(text) {
                         IResult::Done(rest, lit) => {
                             {
-                                let mut ip = new_ip.init_root::<lexical::Builder>();
+                                let mut ip = new_ip.init_root::<fbp_lexical::Builder>();
                                 match lit {
                                     Literal::Bind => { ip.init_token().set_bind(()); },
                                     Literal::External => {ip.init_token().set_external(()); },
@@ -182,7 +182,7 @@ fn handle_stream(comp: &fbp_lexical) -> Result<()> {
                     }
                 }
                 {
-                    let mut ip = new_ip.init_root::<lexical::Builder>();
+                    let mut ip = new_ip.init_root::<fbp_lexical::Builder>();
                     ip.init_token().set_break(());
                 }
                 let mut send_ip = IP::new();
@@ -193,7 +193,7 @@ fn handle_stream(comp: &fbp_lexical) -> Result<()> {
                 let path = try!(path);
                 let mut new_ip = capnp::message::Builder::new_default();
                 {
-                    let mut ip = new_ip.init_root::<lexical::Builder>();
+                    let mut ip = new_ip.init_root::<fbp_lexical::Builder>();
                     ip.set_end(&path);
                 }
                 let mut send_ip = IP::new();

--- a/components/development/fbp/parser/print_graph/Cargo.lock
+++ b/components/development/fbp/parser/print_graph/Cargo.lock
@@ -2,7 +2,7 @@
 name = "print_graph"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/development/fbp/parser/print_graph/default.nix
+++ b/components/development/fbp/parser/print_graph/default.nix
@@ -4,7 +4,7 @@ buildFractalideComponent rec {
   name = genName ./.;
   src = ./.;
   filteredContracts = filterContracts ["fbp_graph"];
-  depsSha256 = "0wdvwxbky4jxddjykr0z25jmvrk1b7hsvphy5icvchnyhzq98ydy";
+  depsSha256 = "1b59snghv3f4lcfwswp0cdacnvzcb9rgiwpr13g84hgnw1c7zlzq";
 
   meta = with stdenv.lib; {
     description = "Component: Flow-based programming graph printer";

--- a/components/development/fbp/parser/print_graph/src/lib.rs
+++ b/components/development/fbp/parser/print_graph/src/lib.rs
@@ -6,7 +6,7 @@ extern crate capnp;
 mod contract_capnp {
     include!("fbp_graph.rs");
 }
-use contract_capnp::graph;
+use contract_capnp::fbp_graph;
 
 component! {
     fbp_print_graph,
@@ -19,7 +19,7 @@ component! {
     fn run(&mut self) -> Result<()> {
         let mut ip = try!(self.ports.recv("input"));
         let graph = try!(ip.get_reader());
-        let graph: graph::Reader = try!(graph.get_root());
+        let graph: fbp_graph::Reader = try!(graph.get_root());
 
         println!("Graph at : {}", try!(graph.get_path()));
         println!("nodes :");

--- a/components/development/fbp/parser/semantic/Cargo.lock
+++ b/components/development/fbp/parser/semantic/Cargo.lock
@@ -2,7 +2,7 @@
 name = "fbp_semantic"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/development/fbp/parser/semantic/default.nix
+++ b/components/development/fbp/parser/semantic/default.nix
@@ -4,7 +4,7 @@ buildFractalideComponent rec {
   name = genName ./.;
   src = ./.;
   filteredContracts = filterContracts ["fbp_semantic_error" "fbp_graph" "fbp_lexical"];
-  depsSha256 = "1mzk49cw0ygamm0s1003zsxxpqj93i3x7yyjyxysngcxn39h4ly9";
+  depsSha256 = "1a13i09r6a9yp7bhkmciyx24769gqqdc36d7k3lxgs7sm7gzgsf4";
 
   meta = with stdenv.lib; {
     description = "Component: Flow-based programming semantics";

--- a/components/development/fbp/scheduler/Cargo.lock
+++ b/components/development/fbp/scheduler/Cargo.lock
@@ -2,7 +2,7 @@
 name = "fvm"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/development/fbp/scheduler/default.nix
+++ b/components/development/fbp/scheduler/default.nix
@@ -3,8 +3,8 @@
 buildFractalideComponent rec {
   name = genName ./.;
   src = ./.;
-  filteredContracts = filterContracts ["fbp_graph" "maths_boolean"];
-  depsSha256 = "0w8b6mldsxqn807sb232m2xb7d9vzlyh5f8rqm6vf5555by3fzw7";
+  filteredContracts = filterContracts ["fbp_graph" "maths_boolean" "path" "generic_text"];
+  depsSha256 = "13f0fyjc9hphzqxh21qr7lcdjv1s617g3ccgxs5l17bgjg5z887l";
 
   meta = with stdenv.lib; {
     description = "Component: Fractalide scheduler";

--- a/components/file/open/Cargo.lock
+++ b/components/file/open/Cargo.lock
@@ -2,7 +2,7 @@
 name = "file_open"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/file/open/default.nix
+++ b/components/file/open/default.nix
@@ -4,7 +4,7 @@ buildFractalideComponent rec {
   name = genName ./.;
   src = ./.;
   filteredContracts = filterContracts ["file" "path" "file_error"];
-  depsSha256 = "1gdl266fp5pgr89yp5dpfbgkvqhcqg7ypjc0jpd9z81n447msg4j";
+  depsSha256 = "1g7ihd0ghavr3f5zd618xplhvkzlxps5sxj06a0xrlk0cfal6jsx";
 
   meta = with stdenv.lib; {
     description = "Component: Opens files";

--- a/components/file/print/Cargo.lock
+++ b/components/file/print/Cargo.lock
@@ -2,7 +2,7 @@
 name = "file_print"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/file/print/default.nix
+++ b/components/file/print/default.nix
@@ -4,7 +4,7 @@ buildFractalideComponent rec {
   name = genName ./.;
   src = ./.;
   filteredContracts = filterContracts ["file"];
-  depsSha256 = "1nfllagp9cgmk0gr6g47iqrbvm7cs3d81482krgj0la8m5p7lgci";
+  depsSha256 = "1flqcsa0mqaql1sxaa9p5gfnlcg9kb8jap5h5h279320gklv8d2w";
 
   meta = with stdenv.lib; {
     description = "Component: Prints the contents of a file";

--- a/components/ip/clone/Cargo.lock
+++ b/components/ip/clone/Cargo.lock
@@ -2,7 +2,7 @@
 name = "file_open"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/ip/clone/default.nix
+++ b/components/ip/clone/default.nix
@@ -4,7 +4,7 @@ buildFractalideComponent rec {
   name = genName ./.;
   src = ./.;
   filteredContracts = filterContracts [];
-  depsSha256 = "0fcssm50404s4bkbwsqir0qwmmj1bbc1b6qd72w8jl08sc4761lr";
+  depsSha256 = "1g7ihd0ghavr3f5zd618xplhvkzlxps5sxj06a0xrlk0cfal6jsx";
 
   meta = with stdenv.lib; {
     description = "Component: Clone the IPs coming in";

--- a/components/maths/boolean/nand/Cargo.lock
+++ b/components/maths/boolean/nand/Cargo.lock
@@ -2,7 +2,7 @@
 name = "maths_boolean_nand"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/maths/boolean/nand/default.nix
+++ b/components/maths/boolean/nand/default.nix
@@ -4,7 +4,7 @@ buildFractalideComponent rec {
   name = genName ./.;
   src = ./.;
   filteredContracts = filterContracts ["maths_boolean"];
-  depsSha256 = "132bjwq6x1g3llvlsb0sg34mryry4my5d79qqmkh0cazmb23w4gm";
+  depsSha256 = "04pdgchvd9pk7zkjdqz75flcpww9rvnhvgz8p0g623ia2fkycyh7";
 
   meta = with stdenv.lib; {
     description = "Component: NAND logic gate";

--- a/components/maths/boolean/nand/src/lib.rs
+++ b/components/maths/boolean/nand/src/lib.rs
@@ -4,16 +4,16 @@ extern crate capnp;
 #[macro_use]
 extern crate rustfbp;
 
-mod maths_boolean {
+mod contract_capnp {
     include!("maths_boolean.rs");
 }
-use self::maths_boolean::boolean;
+use self::contract_capnp::maths_boolean;
 
 component! {
   Nand,
-  inputs(a: boolean, b: boolean),
+  inputs(a: maths_boolean, b: maths_boolean),
   inputs_array(),
-  outputs(output: boolean),
+  outputs(output: maths_boolean),
   outputs_array(),
   option(),
   acc(),
@@ -22,13 +22,13 @@ component! {
     let mut ip_b = try!(self.ports.recv("b"));
     let a_reader = try!(ip_a.get_reader());
     let b_reader = try!(ip_b.get_reader());
-    let a_reader: boolean::Reader = try!(a_reader.get_root());
-    let b_reader: boolean::Reader = try!(b_reader.get_root());
+    let a_reader: maths_boolean::Reader = try!(a_reader.get_root());
+    let b_reader: maths_boolean::Reader = try!(b_reader.get_root());
     let a = a_reader.get_boolean();
     let b = b_reader.get_boolean();
     let mut new_out = capnp::message::Builder::new_default();
     {
-      let mut boolean = new_out.init_root::<boolean::Builder>();
+      let mut boolean = new_out.init_root::<maths_boolean::Builder>();
       boolean.set_boolean(if a == true && b == true {false} else {true});
     }
     ip_a.write_builder(&new_out);

--- a/components/maths/boolean/print/Cargo.lock
+++ b/components/maths/boolean/print/Cargo.lock
@@ -2,7 +2,7 @@
 name = "maths_boolean_nand"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/maths/boolean/print/default.nix
+++ b/components/maths/boolean/print/default.nix
@@ -4,7 +4,7 @@ buildFractalideComponent rec {
   name = genName ./.;
   src = ./.;
   filteredContracts = filterContracts ["maths_boolean"];
-  depsSha256 = "132bjwq6x1g3llvlsb0sg34mryry4my5d79qqmkh0cazmb23w4gm";
+  depsSha256 = "04pdgchvd9pk7zkjdqz75flcpww9rvnhvgz8p0g623ia2fkycyh7";
 
   meta = with stdenv.lib; {
     description = "Component: Print the content of the contract maths_boolean";

--- a/components/maths/boolean/print/src/lib.rs
+++ b/components/maths/boolean/print/src/lib.rs
@@ -3,18 +3,18 @@ extern crate capnp;
 #[macro_use]
 extern crate rustfbp;
 
-mod maths_boolean {
+mod contract_capnp {
     include!("maths_boolean.rs");
 }
-use self::maths_boolean::boolean;
+use self::contract_capnp::maths_boolean;
 
 use std::thread;
 
 component! {
     Nand,
-    inputs(input: boolean),
+    inputs(input: maths_boolean),
     inputs_array(),
-    outputs(output: boolean),
+    outputs(output: maths_boolean),
     outputs_array(),
     option(),
     acc(),
@@ -22,7 +22,7 @@ component! {
         let mut ip_a = try!(self.ports.recv("input"));
 
         let a_reader = try!(ip_a.get_reader());
-        let a_reader: boolean::Reader = try!(a_reader.get_root());
+        let a_reader: maths_boolean::Reader = try!(a_reader.get_root());
         let a = a_reader.get_boolean();
 
         println!("boolean : {:?}", a);

--- a/components/maths/number/add/Cargo.lock
+++ b/components/maths/number/add/Cargo.lock
@@ -2,7 +2,7 @@
 name = "maths_number_add"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/maths/number/add/default.nix
+++ b/components/maths/number/add/default.nix
@@ -4,7 +4,7 @@ buildFractalideComponent rec {
   name = genName ./.;
   src = ./.;
   filteredContracts = filterContracts ["maths_number"];
-  depsSha256 = "11ahbhclxm6f9g0x1f80hbnkm9wbc08zrsqwj5rlnbjyp05pzj3r";
+  depsSha256 = "09pwavy262rjvvmacbg3cbbf620mb7jbazh1znrcmc5brp98bk4h";
 
   meta = with stdenv.lib; {
     description = "Component: Adds all inputs together";

--- a/components/maths/number/add/src/lib.rs
+++ b/components/maths/number/add/src/lib.rs
@@ -3,15 +3,15 @@ extern crate capnp;
 #[macro_use]
 extern crate rustfbp;
 
-mod maths_number {
+mod contract_capnp {
     include!("maths_number.rs");
 }
-use self::maths_number::number;
+use self::contract_capnp::maths_number;
 
 component! {
   Add,
   inputs(),
-  inputs_array(numbers: number),
+  inputs_array(numbers: maths_number),
   outputs(output: number),
   outputs_array(),
   option(),
@@ -21,13 +21,13 @@ component! {
     for ins in try!(self.ports.get_input_selections("numbers")) {
       let mut ip = try!(self.ports.recv_array("numbers", &ins));
       let mut m = try!(ip.get_reader());
-      let m: number::Reader = try!(m.get_root());
+      let m: maths_number::Reader = try!(m.get_root());
       let n = m.get_number();
       acc += n;
     }
     let mut new_m = capnp::message::Builder::new_default();
     {
-      let mut number = new_m.init_root::<number::Builder>();
+      let mut number = new_m.init_root::<maths_number::Builder>();
       number.set_number(acc);
     }
     let mut ip = IP::new();

--- a/contracts/fbp/graph/contract.capnp
+++ b/contracts/fbp/graph/contract.capnp
@@ -1,6 +1,6 @@
 @0x84c8e268d3236b4f;
 
-struct Graph {
+struct FbpGraph {
   path @0 :Text;
   nodes @1 :List(Node);
   edges @2 :List(Edge);

--- a/contracts/fbp/lexical/contract.capnp
+++ b/contracts/fbp/lexical/contract.capnp
@@ -1,6 +1,6 @@
 @0x9c951b3548fca4c2;
 
-struct Lexical {
+struct FbpLexical {
   union {
     start @0 :Text;
     end @1 :Text;

--- a/contracts/fbp/semantic_error/contract.capnp
+++ b/contracts/fbp/semantic_error/contract.capnp
@@ -1,6 +1,6 @@
 @0xf96c29a52799b766;
 
-struct SemanticError {
+struct FbpSemanticError {
   path @0 :Text;
   parsing @1 :List(Text);
 }

--- a/contracts/generic/list_text/contract.capnp
+++ b/contracts/generic/list_text/contract.capnp
@@ -1,5 +1,5 @@
 @0xd1376f2c4c24bf8b;
 
-struct ListText {
+struct GenericListText {
         listText @0 :List(Text);
 }

--- a/contracts/generic/text/contract.capnp
+++ b/contracts/generic/text/contract.capnp
@@ -1,5 +1,5 @@
 @0xb1fc090ed4d12aee;
 
-struct Text {
+struct GenericText {
         text @0 :Text;
 }

--- a/contracts/maths/boolean/contract.capnp
+++ b/contracts/maths/boolean/contract.capnp
@@ -1,5 +1,5 @@
 @0xbde554c96bf60f36;
 
-struct Boolean {
+struct MathsBoolean {
   boolean @0 :Bool;
 }

--- a/contracts/maths/number/contract.capnp
+++ b/contracts/maths/number/contract.capnp
@@ -1,5 +1,5 @@
 @0xbde554c96bf60f25;
 
-struct Number {
+struct MathsNumber {
   number @0 :Int64;
 }

--- a/fvm/fvm-android/Cargo.lock
+++ b/fvm/fvm-android/Cargo.lock
@@ -3,7 +3,7 @@ name = "fvm-android"
 version = "0.1.0"
 dependencies = [
  "android_glue 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -19,7 +19,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -30,7 +30,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -62,7 +62,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/fvm/fvm/Cargo.lock
+++ b/fvm/fvm/Cargo.lock
@@ -2,7 +2,7 @@
 name = "fvm"
 version = "0.1.0"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfbp 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ name = "rustfbp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/fvm/fvm/Cargo.toml
+++ b/fvm/fvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fvm"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Denis Michiels <dmichiels@gmail.com>"]
 license = "AGPL-3.0"
 homepage = "http://github.com/fractalide/fvm"

--- a/fvm/fvm/default.nix
+++ b/fvm/fvm/default.nix
@@ -28,6 +28,8 @@
     ln -s ${components.development_fbp_parser_semantic}/lib/libcomponent.so bootstrap/${components.development_fbp_parser_semantic.name}.so
     cp ${components.development_fbp_parser_print_graph}/lib/libcomponent.so $out/bootstrap/${components.development_fbp_parser_print_graph.name}.so
     ln -s ${components.development_fbp_parser_print_graph}/lib/libcomponent.so bootstrap/${components.development_fbp_parser_print_graph.name}.so
+    cp ${components.development_capnp_encode}/lib/libcomponent.so $out/bootstrap/${components.development_capnp_encode.name}.so
+    ln -s ${components.development_capnp_encode}/lib/libcomponent.so bootstrap/${components.development_capnp_encode.name}.so
     cp ${components.development_fbp_fvm}/lib/libcomponent.so $out/bootstrap/${components.development_fbp_fvm.name}.so
     ln -s ${components.development_fbp_fvm}/lib/libcomponent.so bootstrap/${components.development_fbp_fvm.name}.so
     cp ${components.development_fbp_errors}/lib/libcomponent.so $out/bootstrap/${components.development_fbp_errors.name}.so

--- a/fvm/fvm/src/lib.rs
+++ b/fvm/fvm/src/lib.rs
@@ -67,8 +67,12 @@ pub extern "C" fn run(path_fbp: &str) {
     sched.connect("fvm".into(), "ask_path".into(), "component_lookup".into(), "input".into()).expect("cannot connect");
     sched.connect("component_lookup".into(), "output".into(), "fvm".into(), "new_path".into()).expect("cannot connect");
 
-    sched.connect("fvm".into(), "output".into(), "graph_print".into(), "input".into()).expect("cannot connect");
-    sched.connect("graph_print".into(), "output".into(), "sched".into(), "input".into()).expect("cannot connect");
+    // With Graph print
+    // sched.connect("fvm".into(), "output".into(), "graph_print".into(), "input".into()).expect("cannot connect");
+    // sched.connect("graph_print".into(), "output".into(), "sched".into(), "input".into()).expect("cannot connect");
+
+    // Without Graph print
+    sched.connect("fvm".into(), "output".into(), "sched".into(), "input".into()).expect("cannot connect");
 
     sched.connect("sched".into(), "ask_path".into(), "contract_lookup".into(), "input".into()).expect("cannot connect");
     sched.connect("contract_lookup".into(), "output".into(), "sched".into(), "contract_path".into()).expect("cannot connect");

--- a/rustfbp/Cargo.lock
+++ b/rustfbp/Cargo.lock
@@ -2,7 +2,7 @@
 name = "rustfbp"
 version = "0.3.5"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -14,7 +14,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -25,7 +25,7 @@ name = "capnpc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/rustfbp/src/component.rs
+++ b/rustfbp/src/component.rs
@@ -140,5 +140,31 @@ macro_rules! component {
         pub extern fn create_component(name: String, sched: Sender<CompMsg>) -> Result<(Box<Component + Send>, HashMap<String, IPSender>)> {
             new(name, sched)
         }
+
+        #[no_mangle]
+        pub extern fn get_contract_input(port: &str) -> Result<String> {
+            match port {
+                $(
+                    stringify!($input_field_name)=> Ok(stringify!($input_contract_name).into()),
+                )*
+                $(
+                    stringify!($input_array_name) => Ok(stringify!($input_contract_array).into()),
+                )*
+                _ => { Err(result::Error::PortNotFound) }
+            }
+        }
+
+        #[no_mangle]
+        pub extern fn get_contract_output(port: &str) -> Result<String> {
+            match port {
+                $(
+                    stringify!($output_field_name)=> Ok(stringify!($output_contract_name).into()),
+                )*
+                $(
+                    stringify!($output_array_name) => Ok(stringify!($output_contract_array).into()),
+                )*
+                _ => { Err(result::Error::PortNotFound) }
+            }
+        }
     }
 }

--- a/rustfbp/src/ports.rs
+++ b/rustfbp/src/ports.rs
@@ -13,7 +13,7 @@ use scheduler::CompMsg;
 
 #[derive(Clone)]
 pub struct IP {
-    vec: Vec<u8>,
+    pub vec: Vec<u8>,
 }
 
 impl IP {
@@ -26,6 +26,7 @@ impl IP {
     }
 
     pub fn write_builder<A: capnp::message::Allocator>(&mut self, builder: &capnp::message::Builder<A>) -> Result<()> {
+        self.vec.clear();
         Ok(try!(capnp::serialize::write_message(&mut self.vec, builder)))
     }
 }


### PR DESCRIPTION
Solution : generate the IIP with `capnp encode`

It's now possible to generate an IIP for any contract, with this format : 

```
'maths_boolean:(boolean=true) -> ....
'path:(path="~/test.fbp")' -> ...
```

The format is : 

```
'contract_name:(field=value)' -> ...
```

The contract type must be specified because it's impossible to deduce it in all case. For example : 

```
IIP -> input clone()
```

`clone()` take `any` contract in the `input` input port. Later, the `ide` will perhaps be able to find the contract (what is after `clone()`, ...). 
