### PR TITLE
Problem: nix-rust doesn't compile libloading 1.3.2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,5 +7,6 @@ Copyright (c) 2016-2016 Nixcloud GbR
 Contributors
 ============
 Denis Michiels
+Eric Sagnes
 Paul Seitz
 Stewart Mackenzie

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@ image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images
 
 = Fractalide
 
-**Reusable Reproducible Rust Microservices**
+**Reusable Reproducible Polyglot Services**
 
 image:https://img.shields.io/badge/license-MPLv2-blue.svg[LICENSE,link=https://github.com/fractalide/fractalide/blob/master/LICENSE] image:https://badges.gitter.im/Join%20Chat.svg[Join the chat at \https://gitter.im/fractalide,link=https://gitter.im/fractalide?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge]
 image:https://travis-ci.org/fractalide/fractalide.svg?branch=master["Build Status", link="https://travis-ci.org/fractalide/fractalide"]
@@ -18,8 +18,6 @@ Fractalide is a free and open source service programming platform using dataflow
 Fractalide is in the same vein as the https://en.wikipedia.org/wiki/Apache_NiFi[NSA's Niagrafiles] (now known as https://nifi.apache.org/[Apache-NiFi]) or https://en.wikipedia.org/wiki/TensorFlow[Google's TensorFlow] but stripped of all Java, Python and GUI bloat. Fractalide faces big corporate players like http://abinitio.com/[Ab Initio], a company that charges a lot of money for dataflow solutions.
 
 Truly reusable and reproducible efficient nodes is what differentiates Fractalide from the others. It's this feature that allows open communities to mix and match nodes quickly and easily.
-
-The canonical source of this project is hosted on https://gitlab.com/fractalide/fractalide[GitLab], and is the preferred place for contributions, however if you do not wish to use GitLab, feel free to make issues, on the mirror. However pull requests will only be accepted on GitLab, to make it easy to maintain.
 
 == Features
 
@@ -253,4 +251,3 @@ Follow us on https://twitter.com/fractalide[twitter]
 * Peter Van Roy
 * Pieter Hintjens
 * Joachim Schiele & Paul Seitz of https://nixcloud.io[Nixcloud] who we commissioned to implement https://github.com/fractalide/nixcrates[nixcrates]
-

--- a/modules/rs/rustfbp/Cargo.lock
+++ b/modules/rs/rustfbp/Cargo.lock
@@ -1,10 +1,10 @@
 [root]
 name = "rustfbp"
-version = "0.3.33"
+version = "0.3.34"
 dependencies = [
- "capnp 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libloading 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnp 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threadpool 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -14,21 +14,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
-version = "0.8.0"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "dtoa"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "itoa"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"
@@ -51,89 +41,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libloading"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "target_build_utils 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "phf"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "phf_generator 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rand"
-version = "0.3.15"
+name = "num_cpus"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "serde"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "serde_json"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "target_build_utils"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "phf 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_codegen 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "threadpool"
-version = "1.3.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"
@@ -145,3 +75,14 @@ name = "winapi-build"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[metadata]
+"checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
+"checksum capnp 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c42526d461a93d8a990f30ba51245b6b46c0ed1a761133d2e4fe5b47a9527a45"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
+"checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
+"checksum libloading 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be99f814beb3e9503a786a592c909692bb6d4fc5a695f6ed7987223acfbd5194"
+"checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
+"checksum threadpool 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "066cb721a043c9a0dc694e6a9975686a0c4a3f91a1f3bd0322c3c22aa331ea9c"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/modules/rs/rustfbp/Cargo.toml
+++ b/modules/rs/rustfbp/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "rustfbp"
-version = "0.3.33"
+version = "0.3.34"
 authors = ["Denis Michiels <dmichiels@gmail.com>","Stewart Mackenzie <setori88@gmail.com>"]
 license = "MPL-2.0"
 homepage = "https://gitlab.com/fractalide/fractalide"
-repository = "https://gitlab.com/fractalide/fractalide/tree/master/support/rustfbp"
-description = "Rustfbp provides a simple, composable, clearly defined API, with a C ABI for every agent within a Fractalide microservice deployment."
+repository = "https://github.com/fractalide/fractalide/tree/master/modules/rs/rustfbp"
+description = "Rustfbp provides a simple, composable, clearly defined API, with a C ABI for every agent within a Fractalide deployment."
 
 [dependencies]
-capnp = "^0.8.0"
-libloading = "^0.3.1"
-threadpool = "^1.3.2"
+capnp = "^0.8.10"
+libloading = "^0.4.0"
+threadpool = "^1.6.0"

--- a/modules/rs/rustfbp/src/lib.rs
+++ b/modules/rs/rustfbp/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(question_mark)]
 #![feature(alloc_system)]
 
 extern crate alloc_system;


### PR DESCRIPTION
Solution: update rustfbp dependencies so that nix-rust can build
rustfbp. This is the start of ripping out nixcrates in favour of
https://nest.pijul.com/pmeunier/nix-rust