### PR TITLE
Problem: new edges namespaces doesn't extend into fractals

### DIFF
--- a/edges/capnp/default.nix
+++ b/edges/capnp/default.nix
@@ -24,8 +24,8 @@ in
   FsPath = callPackage ./fs/path {};
   FsFileDesc = callPackage ./fs/file/desc {};
   FsFileError = callPackage ./fs/file/error {};
-  NetHttpEdges = buffet.fractals.net_http.edges;
-  NetNdnEdges = buffet.fractals.net_ndn.edges;
+  NetHttpEdges = buffet.fractals.net_http.edges.capnp;
+  NetNdnEdges = buffet.fractals.net_ndn.edges.capnp;
   NetProtocolDomainPort = callPackage ./net/protocol/domain/port {};
   NetUrl = callPackage ./net/url {};
 

--- a/fractals/app/todo/default.nix
+++ b/fractals/app/todo/default.nix
@@ -4,8 +4,8 @@ let
   fractal = buffet.pkgs.fetchFromGitHub {
     owner = "fractalide";
     repo = "fractal_app_todo";
-    rev = "1393fae895b3e5f431df416334e5e7daa08ba6af";
-    sha256 = "0faqr02qnm84xg6v299h249q5ndbv3xb5qm5czwqff4hj331m3vs";
+    rev = "d1325020574d0aade7930439aec2d6b004329adc";
+    sha256 = "1m5pql94pghrir817g7f1v2dj0g8jk4m44y7z7vf8pf3dqha775c";
   };
   /*fractal = ../../../../fractals/fractal_app_todo;*/
 in

--- a/fractals/net/http/default.nix
+++ b/fractals/net/http/default.nix
@@ -4,8 +4,8 @@ let
   fractal = buffet.pkgs.fetchFromGitHub {
     owner = "fractalide";
     repo = "fractal_net_http";
-    rev = "9f79e0459f756104f989fd8ec1b7aab86afed78c";
-    sha256 = "1amnjgh32kicbsbh2spznipw2yis9szl16nw85c6ihav0x6m8fnz";
+    rev = "4a6b52592e4381b89db8697d4c0922ae89c6e2c4";
+    sha256 = "0xr8wlz1a3qc3775b4j4g3k6dq8ipg044jcch6ypxw4bc3189b53";
   };
   /*fractal = ../../../../fractals/fractal_net_http;*/
 in

--- a/fractals/workbench/default.nix
+++ b/fractals/workbench/default.nix
@@ -4,8 +4,8 @@ let
   fractal = buffet.pkgs.fetchFromGitHub {
     owner = "fractalide";
     repo = "fractal_workbench";
-    rev = "3991d621331913de0a90888074a43e55e322a95d";
-    sha256 = "1cdiyv8lfsawp9h2s8x2whhp2563krmhsgba8zg470hwkpkbwa0k";
+    rev = "e695380a59c4e1de9df3ff2063364fd385b5e4c6";
+    sha256 = "1p16vz81jivglrjwsbhgy40848xdaq0magkiiaq0h1cvbkvx5gv1";
   };
   /*fractal = ../../../fractals/fractal_workbench;*/
 in


### PR DESCRIPTION
Solution: use a recursiveUpdate in fractals to update
the incoming edges from the main fractalide derivation set.
The fractals/* now point to the updated fractals.
Also add the new .capnp namespace on imported fractal edges