### PR TITLE
Problem: main.rkt is not suitable for a launcher

### DIFF
--- a/pkgs/hyperflow/hyperflow
+++ b/pkgs/hyperflow/hyperflow
@@ -1,13 +1,8 @@
-#! /usr/bin/env racket
+#! /usr/bin/env bash
 
-#lang racket/base
+set -e
 
-(require framework/splash
-         racket/lazy-require)
+SCRIPT_NAME=${BASH_SOURCE[0]##*/}
+SCRIPT_DIR=$(cd "${BASH_SOURCE[0]%${SCRIPT_NAME}}" && pwd)
 
-(set-splash-progress-bar?! #t)
-(start-splash "../../doc/images/fractalide.png" " " 0)
-(lazy-require ("main.rkt" (main)))
-(main)
-(shutdown-splash)
-(close-splash)
+exec racket -N "$SCRIPT_NAME" -- "$SCRIPT_DIR/main.rkt" "$@"

--- a/pkgs/hyperflow/main.rkt
+++ b/pkgs/hyperflow/main.rkt
@@ -9,4 +9,11 @@
   (define tl (new toplevel-window%))
   (send tl run))
 
-;(main)
+(module+ main
+  (require framework/splash)
+
+  (set-splash-progress-bar?! #t)
+  (start-splash "../../doc/images/fractalide.png" " " 0)
+  (main)
+  (shutdown-splash)
+  (close-splash))


### PR DESCRIPTION
We have no .rkt file that a launcher (created by raco) could call
into. The splashy startup is put into the 'hyperflow' wrapper.

Solution: Put the splashy startup in a 'main' submodule of main.rkt.

Make the 'hyperflow' script a minimal bash script.