### PR TITLE
Problem: hyperflow is not a racket package

### DIFF
--- a/pkgs/hyperflow/info.rkt
+++ b/pkgs/hyperflow/info.rkt
@@ -1,0 +1,10 @@
+#lang info
+(define collection "hyperflow")
+(define deps '("base" "typed-map"))
+(define build-deps '())
+(define scribblings '())
+(define pkg-desc "An IDE for Fractalide that enables building HyperCard-like applications. Fractalide is a free and open source service programming platform using dataflow graphs.")
+(define version "0.0")
+(define pkg-authors '("setori88@gmail.com"))
+(define racket-launcher-names '("hyperflow"))
+(define racket-launcher-libraries '("main.rkt"))


### PR DESCRIPTION
Solution: Create info.rkt

Install with:

    raco pkg install --deps search-auto path/to/pkgs/hyperflow

This will create a package in your ~/.racket/6.12/pkgs and a
`hyperflow` launcher in your ~/.racket/6.12/bin , so you can start the
program by just running ~/.racket/6.12/bin/hyperflow.

Known issues:
 - It cannot open the splash, unless the splash happens to be in the
   right relative path from your current directory.
 - 'New fractal' will create the fractal directory 5 steps above
   whatever directory you happen to be in. Now that you are likely to
   start hyperflow from just about anywhere, that becomes a genuine
   problem.

Closes #104