### PR TITLE
Problem: raco expects an info.rkt in the root directory

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -7,4 +7,4 @@
 (define version "0.0")
 (define pkg-authors '("setori88@gmail.com"))
 (define racket-launcher-names '("hyperflow"))
-(define racket-launcher-libraries '("main.rkt"))
+(define racket-launcher-libraries '("pkgs/hyperflow/main.rkt"))


### PR DESCRIPTION
Solution: move info.rkt from pkgs/hyperflow to root dir