### PR TITLE
Problem: fractalide.png is relative to the current directory

### DIFF
--- a/pkgs/hyperflow/main.rkt
+++ b/pkgs/hyperflow/main.rkt
@@ -11,9 +11,12 @@
 
 (module+ main
   (require framework/splash)
+  (require racket/runtime-path)
+
+  (define-runtime-path splash-image "imgs/fractalide.png")
 
   (set-splash-progress-bar?! #t)
-  (start-splash "imgs/fractalide.png" " " 0)
+  (start-splash splash-image " " 0)
   (main)
   (shutdown-splash)
   (close-splash))


### PR DESCRIPTION
The splash will only be found if hyperflow is started from within pkgs/hyperflow.

Solution: Use a path relative to the main.rkt file.