### PR TITLE
Problem: no "hello world" for a headless fbp scheduler present

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -7,6 +7,8 @@
 (define version "0.0")
 (define pkg-authors '("setori88@gmail.com"))
 (define racket-launcher-names '("hyperflow"
-                                "fracli"))
+                                "fracli"
+                                "flonly"))
 (define racket-launcher-libraries '("pkgs/hyperflow/hyperflow.rkt"
-                                    "pkgs/hyperflow/fracli.rkt"))
+                                    "pkgs/hyperflow/fracli.rkt"
+                                    "pkgs/hyperflow/flonly.rkt"))

--- a/pkgs/hyperflow/flonly
+++ b/pkgs/hyperflow/flonly
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+set -e
+
+SCRIPT_NAME=${BASH_SOURCE[0]##*/}
+SCRIPT_DIR=$(cd "${BASH_SOURCE[0]%${SCRIPT_NAME}}" && pwd)
+
+exec racket -N "$SCRIPT_NAME" -- "$SCRIPT_DIR/flonly.rkt" "$@"

--- a/pkgs/hyperflow/flonly.rkt
+++ b/pkgs/hyperflow/flonly.rkt
@@ -1,0 +1,5 @@
+#lang racket/base
+
+(module+ main
+  (displayln "Placeholder for the scheduler, this will be included into hyperflow and also gives the user the ability of running a non-gui graph in headless mode"))
+


### PR DESCRIPTION
Solution: flonly (flow only) will give the user the ablity to
execute a non-gui graph in headless mode (without hyperflow)

flonly will also be included into hyperflow to execute gui graphs.
This'll be done by passing the gtk+ run canvas object into the
flonly fbp scheduler, thus providing gui nodes something to
draw on.

Essentially Hyperflow will dynamically reconfigure flonly
on the fly by calling flonly APIs to hotswap and
connect/disconnect nodes that have been compiled by Hyperflow
(via nix). Hyperflow will provide the full nix/store/ path
to the node in question.

The short and unique name "flonly" was chosen as it'll be
executed from the command line. Programmers like short memorable
unique names that won't collide with other cli names in their
environment. "scheduler" would be a bad name as it's too generic.
flonly is also a play on the word "lonely", as one would be
rather lonely without a head. Lastly if one squints one's eyes
and skips a few letters one'll see the word "fly", which
hints at flonly's on the fly graph reconfiguring ability.