### PR TITLE
Problem: fracli.rkt is not what it seems

### DIFF
--- a/pkgs/hyperflow/fracli.rkt
+++ b/pkgs/hyperflow/fracli.rkt
@@ -1,16 +1,9 @@
-#! /usr/bin/env racket
-
 #lang racket/base
 
 (require racket/cmdline
          "fractal-management/default.rkt")
 
-(provide main)
-
-(define (main)
-  (fracli))
-
-(define fracli
+(module+ main
   (command-line
    #:program "fracli"
    #:multi


### PR DESCRIPTION
(command-line) performs its action immediately when called, meaning
the moment fracli is defined. The (main) function does not work.

Solution: Call (command-line) in a "main" submodule.

(require "fracli.rkt") or (require fractalide/pkgs/hyperflow/fracli)
will do nothing, only running it as a direct parameter to racket will
execute the command-line interface.