### PR TITLE
Problem: pkgs/update.sh is cwd-sensitive

### DIFF
--- a/pkgs/update.sh
+++ b/pkgs/update.sh
@@ -2,4 +2,7 @@
 
 set -e
 
+SCRIPT_NAME=${BASH_SOURCE[0]##*/}
+cd "${BASH_SOURCE[0]%${SCRIPT_NAME}}"
+
 nix-shell ../../racket2nix -A racket2nix-env --run "racket2nix ../../fractalide > fractalide.nix"


### PR DESCRIPTION
Solution: Make it cd to the containing directory

Now you can run ./pkgs/update.sh and get fractalide.nix in the right
place.