### PR TITLE
Problem: full racket does not build on Nix/Darwin

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -14,8 +14,11 @@ in (pkgs {
         rustc = nightly.rust;
         inherit (nightly) cargo;
       };
+      racket = if super.stdenv.isDarwin then super.racket.overrideDerivation (drv: {
+        buildInputs = drv.buildInputs ++ [ super.libiconv ];
+      }) else super.racket;
       rustPlatform = super.recurseIntoAttrs (super.makeRustPlatform rust);
-      fractalide = super.callPackage ./fractalide.nix {};
+      fractalide = self.callPackage ./fractalide.nix {};
     })
   ];
 })


### PR DESCRIPTION
See NixOS/nixpkgs#35429 .

It's not good enough to merge into nixpkgs, but it's good enough to
build.

Solution: On Nix/Darwin, make racket use GNU libiconv.

Now pkgs.fractalide builds.

Known issues:

```
$ $(nix-build --no-out-link -A pkgs.fractalide)/bin/hyperflow
[ . . . ]
ffi-lib: couldn't open "libX11.6.dylib" (dlopen(libX11.6.dylib, 6): image not found)
  context...:
   /nix/store/i4lc5qygg6jzdy5p0fam7s7p700c6agj-racket-6.12/share/racket/pkgs/gui-lib/mred/private/wx/gtk/x11.rkt: [running body]
```

```
$ DYLD_LIBRARY_PATH=$(nix-build --no-out-link -A pkgs.xorg.libX11)/lib:$DYLD_LIBRARY_PATH $(nix-build --no-out-link -A pkgs.fractalide)/bin/hyperflow
[ . . . ]
Segmentation fault: 11
```

```
$ DYLD_LIBRARY_PATH=$(nix-build --no-out-link -A pkgs.xorg.libX11)/lib:$DYLD_LIBRARY_PATH $(nix-build --no-out-link -A pkgs.fractalide)/bin/hyperflow
racket(11288,0x7fffda7df3c0) malloc: *** error for object 0x10e430d68: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
Abort trap: 6
```

But it builds!