### PR TITLE
Problem: hyperflow supports osx, travis currently doesn't build osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ matrix:
       dist: trusty
       script:
         - nix-build tests
+    - os: osx
+      script:
+        - nix-build tests


### PR DESCRIPTION
Solution: add osx to the build matrix

Might need to do a few `git push origin <branch> -f` to get this to work properly, so don't merge immediately please.