### PR TITLE
Problem: travis doesn't support osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ matrix:
     - os: linux
       script:
         - nix-build tests
+        - nix-build -A pkgs.fractalide
     - os: linux
       dist: trusty
       script:
         - nix-build tests
+        - nix-build -A pkgs.fractalide
     - os: osx
       script:
-        - nix-build tests
+        - nix-build -A pkgs.fractalide


### PR DESCRIPTION
Solution: add osx to the build matrix but don't build
nix-build tests because libloading doesn't support darwin
the rust side of things is an optimization that'll come
in later

**** @gazhayes please don't merge yet ****