### PR TITLE
Problem: testing on darwin means building all of racket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,3 @@ matrix:
       script:
         - nix-build tests
         - nix-build -A pkgs.fractalide
-    - os: osx
-      script:
-        - nix-build -A pkgs.fractalide


### PR DESCRIPTION
This will time out every time. If we want to test on darwin, we have a
few options:

 - Solve NixOS/nixpkgs#35429
   Get racket into nixpkgs, so we can pull down racket from hydra.

 - Solve fractalide/racket2nix#94
   Make racket2nix competent enough that we don't get the empty.zip
   sources for core packages, and can build on racket-minimal.

 - Massage the catalogs
   If we make sure that the core packages come from the release
   catalog instead of the live catalog, it should work. This is
   probably as easy as a union between two hashes. We could even
   cheat and just manually add only typed-map to the release
   catalog.

Solution: Disable darwin for now.