### PR TITLE
Problem: we are not testing on darwin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ matrix:
       script:
         - nix-build tests
         - nix-build -A pkgs.fractalide
+    - os: osx
+      script:
+        - nix-build -A pkgs.fractalide

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -21,12 +21,6 @@ pkgs {
         rustc = nightly.rust;
         inherit (nightly) cargo;
       };
-      racket = if super.stdenv.isDarwin then super.racket.overrideDerivation (drv: {
-        buildInputs = drv.buildInputs ++ [ super.libiconv ];
-        meta = drv.meta.overrideAttrs (attrs: {
-          platforms = attrs.platforms ++ [ "x86_64-darwin" ];
-        });
-      }) else super.racket;
       inherit racket2nix;
       inherit (racket2nix) buildRacket;
       rustPlatform = super.recurseIntoAttrs (super.makeRustPlatform rust);

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -11,7 +11,7 @@
     repo   = "racket2nix";
     rev    = "20354a92230bf5c9aeb53aa5e6d9720dbd8380e5";
     sha256 = "1z2ni1b3zh8hx8wnzdipyi7ys06zwm4kqzql6d0555dy3y18g70m";
-  }) { }
+  }) { racket = (pkgs {}).racket-minimal; }
 }:
 pkgs {
   overlays = [


### PR DESCRIPTION
With the buildRacket improvement and the merged catalog, we are now
building on racket-minimal. This means darwin works!

Solution: Add osx back to the travis matrix.

This reverts commit df04049.
This reverts #124 .