### PR TITLE
Problem: No Racket FBP scheduler

### DIFF
--- a/modules/rkt/rkt-fbp/agent.rkt
+++ b/modules/rkt/rkt-fbp/agent.rkt
@@ -1,0 +1,45 @@
+#lang typed/racket
+
+; TODO : what to do with unconnected output port?
+
+(provide (struct-out agent) (struct-out opt-agent) make-agent recv send)
+
+(require rkt-fbp/port)
+
+(struct agent([inport : (Immutable-HashTable String port)]
+              [outport : (Immutable-HashTable String (U False port))]
+              [proc : (-> agent Void)]
+              [sched : Thread]) #:transparent)
+
+(struct opt-agent([inport : (Listof String)]
+                  [outport : (Listof String)]
+                  [proc : (-> agent Void)]) #:transparent)
+
+(: recv (-> agent String Any))
+(define (recv agent port)
+  (port-recv (hash-ref (agent-inport agent) port)))
+
+(: send (-> agent String Any Void))
+(define (send agent port msg)
+  (let ([out-port (hash-ref (agent-outport agent) port)])
+    (if out-port
+        (port-send out-port msg)
+        (void))))
+
+(: build-inport (-> (Listof String) String Thread (Immutable-HashTable String port)))
+(define (build-inport inputs name sched)
+  (for/hash: : (Immutable-HashTable String port) ([input inputs])
+    (values input (make-port 10 name sched))))
+
+(: build-outport (-> (Listof String) (Immutable-HashTable String False)))
+(define (build-outport outputs)
+  (for/hash: : (Immutable-HashTable String False) ([output outputs])
+    (values output #f)))
+
+(: make-agent (-> opt-agent String Thread agent))
+(define (make-agent opt name sched)
+  (agent
+   (build-inport (opt-agent-inport opt) name sched)
+   (build-outport (opt-agent-outport opt))
+   (opt-agent-proc opt)
+   sched)) ;TODO check if useful

--- a/modules/rkt/rkt-fbp/agents/adder.rkt
+++ b/modules/rkt/rkt-fbp/agents/adder.rkt
@@ -1,0 +1,11 @@
+#lang racket
+
+(provide agt)
+
+(require rkt-fbp/agent)
+(require rkt-fbp/port)
+
+(define agt (opt-agent '("in") '("out")
+                         (lambda (self)
+                           (let ([msg (recv self "in")])
+                             (send self "out" (+ msg 10))))))

--- a/modules/rkt/rkt-fbp/agents/displayer.rkt
+++ b/modules/rkt/rkt-fbp/agents/displayer.rkt
@@ -1,0 +1,11 @@
+#lang racket
+
+(provide agt)
+
+(require rkt-fbp/agent)
+(require rkt-fbp/port)
+
+(define agt (opt-agent '("in") '()
+                             (lambda (self)
+                               (display "msg received: ")
+                               (displayln (recv self "in")))))

--- a/modules/rkt/rkt-fbp/loader.rkt
+++ b/modules/rkt/rkt-fbp/loader.rkt
@@ -1,0 +1,7 @@
+#lang racket
+
+(provide load-agent)
+
+(define (load-agent path)
+  (let ([agt (dynamic-require path 'agt)])
+    agt))

--- a/modules/rkt/rkt-fbp/main.rkt
+++ b/modules/rkt/rkt-fbp/main.rkt
@@ -1,0 +1,14 @@
+#lang typed/racket
+
+(require rkt-fbp/scheduler)
+(require rkt-fbp/msg)
+
+(define sched (make-scheduler #f))
+(sched (msg-add-agent "adder" "add"))
+(sched (msg-add-agent "displayer" "disp"))
+(sched (msg-connect "add" "out" "disp" "in"))
+
+(sched (msg-iip "add" "in" 5))
+(sched (msg-iip "add" "in" 3))
+
+(sleep 0.5)

--- a/modules/rkt/rkt-fbp/msg.rkt
+++ b/modules/rkt/rkt-fbp/msg.rkt
@@ -1,0 +1,24 @@
+#lang typed/racket
+
+(provide (all-defined-out))
+
+(struct msg-set-scheduler-thread ([t : Thread]))
+(struct msg-add-agent ([type : String] [name : String]))
+(struct msg-connect ([out : String][port-out : String][in : String][port-in : String]))
+(struct msg-iip ([agt : String][port : String][iip : Any]))
+(struct msg-inc-ip ([agt : String]))
+(struct msg-dec-ip ([agt : String]))
+(struct msg-run-end ([agt : String]))
+(struct msg-display ())
+(struct msg-quit ())
+(struct msg-run ([agt : String]))
+(define-type Msg (U msg-set-scheduler-thread
+                    msg-add-agent
+                    msg-connect
+                    msg-iip
+                    msg-inc-ip
+                    msg-dec-ip
+                    msg-run-end
+                    msg-display
+                    msg-quit
+                    msg-run))

--- a/modules/rkt/rkt-fbp/port.rkt
+++ b/modules/rkt/rkt-fbp/port.rkt
@@ -1,0 +1,33 @@
+#lang typed/racket
+
+(provide port make-port port-send port-recv port-try-recv)
+
+(require typed/racket/async-channel)
+(require rkt-fbp/msg)
+
+(struct port([channel : (Async-Channelof Any)]
+             [name : String ]
+             [thd : Thread]))
+
+(: make-port (-> Exact-Positive-Integer String Thread port))
+(define (make-port size name thd)
+    (port (make-async-channel size) name thd))
+
+(: port-send (-> port Any Void))
+(define (port-send self msg)
+  (async-channel-put (port-channel self) msg)
+  (thread-send (port-thd self) (msg-inc-ip (port-name self))))
+
+(: port-recv (-> port Any))
+(define (port-recv self)
+  (thread-send (port-thd self) (msg-dec-ip (port-name self)))
+  (async-channel-get (port-channel self)))
+
+(: port-try-recv (-> port Any))
+(define (port-try-recv self)
+  (let ([msg (async-channel-try-get (port-channel self))])
+    (if msg
+        (begin
+          (thread-send (port-thd self) (msg-dec-ip (port-name self)))
+          msg)
+        #f)))

--- a/modules/rkt/rkt-fbp/scheduler.rkt
+++ b/modules/rkt/rkt-fbp/scheduler.rkt
@@ -1,0 +1,141 @@
+#lang typed/racket
+
+; (provide make-scheduler (struct-out scheduler))
+(provide make-scheduler (struct-out scheduler))
+
+(require rkt-fbp/agent)
+(require rkt-fbp/port)
+(require rkt-fbp/msg)
+
+(require/typed rkt-fbp/loader
+  [load-agent (-> String opt-agent)])
+
+; TODO : make sender that cannot read the channel
+
+(struct agent-state([state : agent]
+                    [number-ips : Integer] ; Check for Integer -> Natural
+                    [is-running : Boolean]) #:transparent)
+
+(struct scheduler([agents : (Immutable-HashTable String agent-state)]
+                  [thd : Thread]) #:transparent)
+
+(: scheduler-loop (-> scheduler Void))
+(define (scheduler-loop self)
+  (let ([msg (thread-receive)])
+    (match msg
+      [(msg-set-scheduler-thread t)
+       (scheduler-loop (struct-copy scheduler self [thd t]))]
+      [(msg-add-agent type name)
+       (let* ([path (string-append "./agents/" type ".rkt")]
+              [agt (load-agent path)]
+              [agt (make-agent agt name (scheduler-thd self))]
+              [old-agent (scheduler-agents self)]
+              [agt-state (agent-state agt 0 #f)]
+              [new-agents (hash-set old-agent name agt-state)])
+         (scheduler-loop (struct-copy scheduler self [agents new-agents])))]
+      [(msg-run agt)
+       (let* ([agents (scheduler-agents self)]
+              [agt (hash-ref agents agt)]
+              [agt (agent-state-state agt)]
+              [in (agent-inport agt)]
+              [proc (agent-proc agt)])
+         ((cast proc (-> agent Void)) agt)
+         )]
+      [(msg-connect out port-out in port-in)
+       (let* ([agents (scheduler-agents self)]
+              [in-agt-state (hash-ref agents in)]
+              [in-agt (agent-state-state in-agt-state)]
+              [port (hash-ref (agent-inport in-agt) port-in)]
+              [out-agt-state (hash-ref agents out)]
+              [out-agt (agent-state-state out-agt-state)]
+              [old-outport (agent-outport out-agt)]
+              [new-outport (hash-set old-outport port-out port)]
+              [new-out-agt (struct-copy agent out-agt [outport new-outport])]
+              [new-agent-state (struct-copy agent-state out-agt-state [state new-out-agt])]
+              [new-agents (hash-set agents out new-agent-state)]
+              )
+         (scheduler-loop (struct-copy scheduler self [agents new-agents]))
+         )
+       ]
+      [(msg-iip agt port iip)
+       (let* ([agents (scheduler-agents self)]
+              [in-agt-state (hash-ref agents agt)]
+              [in-agt (agent-state-state in-agt-state)]
+              [port (hash-ref (agent-inport in-agt) port)]
+              )
+         (port-send port iip)
+         (scheduler-loop self))]
+      [(msg-inc-ip agt)
+       (let* ([agents (scheduler-agents self)]
+              [agt-state (hash-ref agents agt)]
+              [nbr (agent-state-number-ips agt-state)]
+              [new-agt-state (struct-copy agent-state agt-state [number-ips (+ nbr 1)])]
+              [new-agents (hash-set agents agt new-agt-state)]
+              [new-self (struct-copy scheduler self [agents new-agents])])
+         ; Increase number of saved IP
+         (scheduler-loop (exec-agent new-self agt))
+       )]
+      [(msg-dec-ip agt)
+       (let* ([agents (scheduler-agents self)]
+              [agt-state (hash-ref agents agt)]
+              [nbr (agent-state-number-ips agt-state)]
+              [new-agt-state (struct-copy agent-state agt-state [number-ips (- nbr 1)])]
+              [new-agents (hash-set agents agt new-agt-state)]
+              [new-self (struct-copy scheduler self [agents new-agents])])
+         (scheduler-loop new-self)
+         )]
+      [(msg-run-end agt-name)
+       (let* ([agents (scheduler-agents self)]
+              [agt-state (hash-ref agents agt-name)]
+              [new-agt-state (struct-copy agent-state agt-state [is-running #f])]
+              [new-agents (hash-set agents agt-name new-agt-state)]
+              [new-state (struct-copy scheduler self [agents new-agents])])
+         (scheduler-loop (exec-agent new-state agt-name))
+         )
+       ]
+      [(msg-display) (displayln self) (scheduler-loop self)]
+      [(msg-quit) (displayln "Scheduler shut down")]
+      [else (display "unknown msg : ") (displayln msg)
+            (scheduler-loop self)]
+      )
+    )
+  )
+
+(: exec-agent (-> scheduler String scheduler))
+(define (exec-agent state agt-name)
+  ; Look if the agent have to run (not running yet and at least one IP)
+  (let* ([agents (scheduler-agents state)]
+         [sched (scheduler-thd state)]
+         [agt-state (hash-ref agents agt-name)]
+         [is-running (agent-state-is-running agt-state)]
+         [agt (agent-state-state agt-state)]
+         [proc (agent-proc agt)]
+         [nbr-ips (agent-state-number-ips agt-state)])
+    (if (and (not is-running) (> nbr-ips 0))
+        ;true -> must run
+        ; change is-running to true and exec
+        (begin
+          (thread (lambda ()
+                    (proc agt)
+                    (thread-send sched (msg-run-end agt-name))))
+          (let* ([new-agt-state (struct-copy agent-state agt-state [is-running #t])]
+               [new-agents (hash-set agents agt-name new-agt-state)]
+               [new-state (struct-copy scheduler state [agents new-agents])])
+          new-state))
+        ;false -> do nothing
+        state
+        )
+    )
+  )
+
+(: make-scheduler (-> False (-> Msg Void)))
+(define (make-scheduler opt)
+  (let* ([state (scheduler #hash() (thread (lambda() (void))))] ;TODO : use an option instead of an empty thread
+         [t (thread (lambda() (scheduler-loop state)))]
+         )
+    (thread-send t (msg-set-scheduler-thread t))
+    (lambda (msg)
+      (thread-send t msg)
+      )
+    )
+  )


### PR DESCRIPTION
Solution:
This first commit add a basic scheduler for a racket FBP framework.
There still many to do :
- Make the scheduler terminate cleanly
- Array-ports
- Option port
- Acc port
- subnet
- ...

This version come with a working example in main.rkt, which is :

```
5 -> in add(adder) out -> in disp(displayer)
3 -> in add()
```