### PR TITLE
Problem: rkt-fbp doesn't package

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 (define collection "fractalide")
-(define deps '("base" "gui-lib" "typed-map-lib"))
+(define deps '("base" "gui-lib" "typed-map-lib" "typed-racket-more"))
 (define build-deps '())
 (define scribblings '())
 (define pkg-desc "An IDE for Fractalide that enables building HyperCard-like applications. Fractalide is a free and open source service programming platform using dataflow graphs.")

--- a/modules/rkt/rkt-fbp/agent.rkt
+++ b/modules/rkt/rkt-fbp/agent.rkt
@@ -4,7 +4,7 @@
 
 (provide (struct-out agent) (struct-out opt-agent) make-agent recv send)
 
-(require rkt-fbp/port)
+(require fractalide/modules/rkt/rkt-fbp/port)
 
 (struct agent([inport : (Immutable-HashTable String port)]
               [outport : (Immutable-HashTable String (U False port))]

--- a/modules/rkt/rkt-fbp/agents/adder.rkt
+++ b/modules/rkt/rkt-fbp/agents/adder.rkt
@@ -2,8 +2,8 @@
 
 (provide agt)
 
-(require rkt-fbp/agent)
-(require rkt-fbp/port)
+(require fractalide/modules/rkt/rkt-fbp/agent)
+(require fractalide/modules/rkt/rkt-fbp/port)
 
 (define agt (opt-agent '("in") '("out")
                          (lambda (self)

--- a/modules/rkt/rkt-fbp/agents/displayer.rkt
+++ b/modules/rkt/rkt-fbp/agents/displayer.rkt
@@ -2,8 +2,8 @@
 
 (provide agt)
 
-(require rkt-fbp/agent)
-(require rkt-fbp/port)
+(require fractalide/modules/rkt/rkt-fbp/agent)
+(require fractalide/modules/rkt/rkt-fbp/port)
 
 (define agt (opt-agent '("in") '()
                              (lambda (self)

--- a/modules/rkt/rkt-fbp/main.rkt
+++ b/modules/rkt/rkt-fbp/main.rkt
@@ -1,7 +1,7 @@
 #lang typed/racket
 
-(require rkt-fbp/scheduler)
-(require rkt-fbp/msg)
+(require fractalide/modules/rkt/rkt-fbp/scheduler)
+(require fractalide/modules/rkt/rkt-fbp/msg)
 
 (define sched (make-scheduler #f))
 (sched (msg-add-agent "adder" "add"))

--- a/modules/rkt/rkt-fbp/port.rkt
+++ b/modules/rkt/rkt-fbp/port.rkt
@@ -3,7 +3,7 @@
 (provide port make-port port-send port-recv port-try-recv)
 
 (require typed/racket/async-channel)
-(require rkt-fbp/msg)
+(require fractalide/modules/rkt/rkt-fbp/msg)
 
 (struct port([channel : (Async-Channelof Any)]
              [name : String ]

--- a/modules/rkt/rkt-fbp/scheduler.rkt
+++ b/modules/rkt/rkt-fbp/scheduler.rkt
@@ -3,11 +3,11 @@
 ; (provide make-scheduler (struct-out scheduler))
 (provide make-scheduler (struct-out scheduler))
 
-(require rkt-fbp/agent)
-(require rkt-fbp/port)
-(require rkt-fbp/msg)
+(require fractalide/modules/rkt/rkt-fbp/agent)
+(require fractalide/modules/rkt/rkt-fbp/port)
+(require fractalide/modules/rkt/rkt-fbp/msg)
 
-(require/typed rkt-fbp/loader
+(require/typed fractalide/modules/rkt/rkt-fbp/loader
   [load-agent (-> String opt-agent)])
 
 ; TODO : make sender that cannot read the channel


### PR DESCRIPTION
Because we have the info.rkt in the root of our repo, racket expects
the modules to be referred to as fractalide/modules/rkt/rkt-fbp/...

The typed-racket-more dependency is not declared.

Solution: Adjust the require{,/typed} statements to use the longer
path. Add the typed-racket-more dependency.

It's not pretty. We should probably reconsider our repo structure.