### PR TITLE
Problem: rkt-fbp binary has no launcher

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -8,7 +8,9 @@
 (define pkg-authors '("setori88@gmail.com"))
 (define racket-launcher-names '("hyperflow"
                                 "fracli"
-                                "flonly"))
+                                "flonly"
+                                "rkt-fbp"))
 (define racket-launcher-libraries '("pkgs/hyperflow/hyperflow.rkt"
                                     "pkgs/hyperflow/fracli.rkt"
-                                    "pkgs/hyperflow/flonly.rkt"))
+                                    "pkgs/hyperflow/flonly.rkt"
+                                    "modules/rkt/rkt-fbp/main.rkt"))


### PR DESCRIPTION
Solution: Add rkt-fbp to racket-launcher-*

Known issue: When running rkt-fbp, you need to be in the right cwd:

    $ cd modules/rkt/rkt-fbp
    $ nix-build ../../../ -A pkgs.fractalide
    building '/nix/store/9hlmfs433bmziqxcxnh83amjw88h4h6m-racket-package.nix.drv'...
    [ . . . ]
    building '/nix/store/6245rlbyhwxhxsy5pxg9qi29v0q7dlsz-fractalide.drv'...
    [ . . . ]
    /nix/store/1rr5xcgj94kc6qr98qy8lcfx25hsd554-fractalide
    $ ./result/bin/rkt-fbp
    msg received: 15
    msg received: 13