### PR TITLE
Problem: pkgs.fractalide is sensitive to result symlinks

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -24,7 +24,11 @@ pkgs {
       inherit racket2nix;
       inherit (racket2nix) buildRacket;
       rustPlatform = super.recurseIntoAttrs (super.makeRustPlatform rust);
-      fractalide = self.buildRacket { package = ./..; };
+      fractalide = self.buildRacket {
+        package = builtins.filterSource
+          (path: type: type != "symlink" || null == builtins.match "result.*" (baseNameOf path))
+          ./..;
+      };
     })
   ];
 }


### PR DESCRIPTION
When you nix-build, normally you will leave behind a `result` symlink
in the directory where you ran it. When our whole repo is a source
input to `pkgs.fractalide`, that means that every time you run
nix-build inside the repo, it needs to build again, even if that
symlink is all that changed.

Solution: Filter out symlinks that start with 'result'.