### PR TITLE
Problem : No Racket FBP scheduler #127

### DIFF
--- a/modules/rkt/rkt-fbp/agent.rkt
+++ b/modules/rkt/rkt-fbp/agent.rkt
@@ -2,18 +2,39 @@
 
 ; TODO : what to do with unconnected output port?
 
-(provide (struct-out agent) (struct-out opt-agent) make-agent recv send)
+(provide (struct-out agent)
+         (struct-out opt-agent)
+         recv
+         send
+         agent-connect
+         agent-connect-to-array
+         agent-connect-array-to
+         make-agent)
 
 (require fractalide/modules/rkt/rkt-fbp/port)
 
+(define-type in-array-port
+  (Immutable-HashTable String (cons Integer port)))
+
+(define-type out-array-port
+  (Immutable-HashTable String port))
+
 (struct agent([inport : (Immutable-HashTable String port)]
+              [in-array-port : (Immutable-HashTable String in-array-port)]
               [outport : (Immutable-HashTable String (U False port))]
+              [out-array-port : (Immutable-HashTable String out-array-port)]
               [proc : (-> agent Void)]
               [sched : Thread]) #:transparent)
 
 (struct opt-agent([inport : (Listof String)]
+                  [in-array : (Listof String)]
                   [outport : (Listof String)]
+                  [out-array : (Listof String)]
                   [proc : (-> agent Void)]) #:transparent)
+
+;;
+;; Methods for using the agent
+;;
 
 (: recv (-> agent String Any))
 (define (recv agent port)
@@ -26,20 +47,93 @@
         (port-send out-port msg)
         (void))))
 
+
+;;
+;; Methods for manipulate the agent
+;;
+
+; Connect
+(: agent-connect (-> agent String port agent))
+(define (agent-connect self port sender)
+  (let* ([out (agent-outport self)]
+        [new-port (hash-set out port sender)])
+    (struct-copy agent self [outport new-port])))
+
+; Connect-to-array
+; It retrieve the Sender from an input port
+(: agent-connect-to-array (-> agent String String String Thread (values port agent)))
+(define (agent-connect-to-array self port selection name sched)
+  (let* ([in (agent-in-array-port self)]
+         [array (hash-ref in port)]
+         [selec (hash-ref array selection #f)])
+    (if selec
+        ; Already existing, add 1 and return
+        (let* ([sender (cdr selec)]
+               [new-selec (cons (+ (car selec) 1) sender)]
+               [new-array (hash-set array selection new-selec)]
+               [new-in (hash-set in port new-array)]
+               [new-agent (struct-copy agent self [in-array-port new-in])])
+          (values sender new-agent))
+        ; Not yet existing, set at 1, create and return
+        (let* ([sender (make-port 30 name sched)]
+               [new-selec (cons 1 sender)]
+               [new-array (hash-set array selection new-selec)]
+               [new-in (hash-set in port new-array)]
+               [new-agent (struct-copy agent self [in-array-port new-in])])
+          (values sender new-agent)))))
+
+; Connect-array-to
+; It set a sender to an array output port
+(: agent-connect-array-to (-> agent String String port agent))
+(define (agent-connect-array-to self port selection sender)
+  (let* ([out (agent-out-array-port self)]
+         [array (hash-ref out port)]
+         [new-array (hash-set array selection sender)]
+         [new-out (hash-set out port new-array)])
+    (struct-copy agent self [out-array-port new-out])
+    )
+  )
+
+; disconnect
+; disconnect-to-array
+; disconnect-array-to
+
+;;
+;; Methods for building the agent
+;; privates
+;;
+
 (: build-inport (-> (Listof String) String Thread (Immutable-HashTable String port)))
 (define (build-inport inputs name sched)
   (for/hash: : (Immutable-HashTable String port) ([input inputs])
-    (values input (make-port 10 name sched))))
+    (values input (make-port 30 name sched))))
 
 (: build-outport (-> (Listof String) (Immutable-HashTable String False)))
 (define (build-outport outputs)
   (for/hash: : (Immutable-HashTable String False) ([output outputs])
     (values output #f)))
 
+(: build-in-array-port (-> (Listof String) (Immutable-HashTable String in-array-port)))
+(define (build-in-array-port inputs)
+  (for/hash: : (Immutable-HashTable String in-array-port) ([input inputs])
+    (let ([empty : in-array-port (make-immutable-hash)])
+      (values input empty))))
+
+(: build-out-array-port (-> (Listof String) (Immutable-HashTable String out-array-port)))
+(define (build-out-array-port inputs)
+  (for/hash: : (Immutable-HashTable String out-array-port) ([input inputs])
+    (let ([empty : out-array-port (make-immutable-hash)])
+      (values input empty))))
+;;
+;; The method to create an agent
+;;
+
 (: make-agent (-> opt-agent String Thread agent))
 (define (make-agent opt name sched)
   (agent
    (build-inport (opt-agent-inport opt) name sched)
+   (build-in-array-port (opt-agent-in-array opt))
    (build-outport (opt-agent-outport opt))
+   (build-out-array-port (opt-agent-out-array opt))
    (opt-agent-proc opt)
    sched)) ;TODO check if useful

--- a/modules/rkt/rkt-fbp/agents/adder.rkt
+++ b/modules/rkt/rkt-fbp/agents/adder.rkt
@@ -5,7 +5,11 @@
 (require fractalide/modules/rkt/rkt-fbp/agent)
 (require fractalide/modules/rkt/rkt-fbp/port)
 
-(define agt (opt-agent '("in") '("out")
-                         (lambda (self)
-                           (let ([msg (recv self "in")])
-                             (send self "out" (+ msg 10))))))
+(define agt (opt-agent
+             '("in") ; in port
+             '() ; in array port
+             '("out") ; out port
+             '() ; out array port
+             (lambda (self)
+               (let ([msg (recv self "in")])
+                 (send self "out" (+ msg 10))))))

--- a/modules/rkt/rkt-fbp/agents/adder.rkt
+++ b/modules/rkt/rkt-fbp/agents/adder.rkt
@@ -6,10 +6,14 @@
 (require fractalide/modules/rkt/rkt-fbp/port)
 
 (define agt (opt-agent
-             '("in") ; in port
-             '() ; in array port
+             '() ; in port
+             '("in") ; in array port
              '("out") ; out port
              '() ; out array port
              (lambda (self)
-               (let ([msg (recv self "in")])
-                 (send self "out" (+ msg 10))))))
+               (let* ([in-array (agent-in-array-port self)]
+                      [array (hash-ref in-array "in")])
+                 (define sum (for/fold ([sum 0])
+                                       ([(k v) array])
+                               (+ sum (port-recv (cdr v)))))
+                 (send self "out" sum)))))

--- a/modules/rkt/rkt-fbp/agents/clone.rkt
+++ b/modules/rkt/rkt-fbp/agents/clone.rkt
@@ -1,0 +1,18 @@
+#lang racket
+
+(provide agt)
+
+(require fractalide/modules/rkt/rkt-fbp/agent)
+(require fractalide/modules/rkt/rkt-fbp/port)
+
+(define agt (opt-agent
+             '("in") ; in port
+             '() ; in array port
+             '() ; out port
+             '("out") ; out array port
+             (lambda (self)
+               (let* ([msg (recv self "in")]
+                     [out-array (agent-out-array-port self)]
+                     [array (hash-ref out-array "out")])
+                 (for ([(k v) array])
+                   (port-send v msg))))))

--- a/modules/rkt/rkt-fbp/agents/displayer.rkt
+++ b/modules/rkt/rkt-fbp/agents/displayer.rkt
@@ -8,8 +8,10 @@
 (define agt (opt-agent
              '("in") ; in port
              '() ; in array port
-             '() ; out port
+             '("out") ; out port
              '() ; out array port
              (lambda (self)
+               (define msg (recv self "in"))
                (display "msg received: ")
-               (displayln (recv self "in")))))
+               (displayln msg)
+               (send self "out" msg))))

--- a/modules/rkt/rkt-fbp/agents/displayer.rkt
+++ b/modules/rkt/rkt-fbp/agents/displayer.rkt
@@ -5,7 +5,11 @@
 (require fractalide/modules/rkt/rkt-fbp/agent)
 (require fractalide/modules/rkt/rkt-fbp/port)
 
-(define agt (opt-agent '("in") '()
-                             (lambda (self)
-                               (display "msg received: ")
-                               (displayln (recv self "in")))))
+(define agt (opt-agent
+             '("in") ; in port
+             '() ; in array port
+             '() ; out port
+             '() ; out array port
+             (lambda (self)
+               (display "msg received: ")
+               (displayln (recv self "in")))))

--- a/modules/rkt/rkt-fbp/main.rkt
+++ b/modules/rkt/rkt-fbp/main.rkt
@@ -12,3 +12,4 @@
 (sched (msg-iip "add" "in" 3))
 
 (sleep 0.5)
+(sched (msg-stop))

--- a/modules/rkt/rkt-fbp/main.rkt
+++ b/modules/rkt/rkt-fbp/main.rkt
@@ -6,10 +6,14 @@
 (define sched (make-scheduler #f))
 (sched (msg-add-agent "adder" "add"))
 (sched (msg-add-agent "displayer" "disp"))
+(sched (msg-add-agent "displayer" "disp1"))
+(sched (msg-add-agent "clone" "clone"))
 (sched (msg-connect "add" "out" "disp" "in"))
+(sched (msg-connect-array-to-array "clone" "out" "1" "add" "in" "1"))
+(sched (msg-connect-array-to "clone" "out" "2" "disp1" "in"))
+(sched (msg-connect-to-array "disp1" "out" "add" "in" "2"))
 
-(sched (msg-iip "add" "in" 5))
-(sched (msg-iip "add" "in" 3))
+(sched (msg-iip "clone" "in" 5))
 
 (sleep 0.5)
 (sched (msg-stop))

--- a/modules/rkt/rkt-fbp/msg.rkt
+++ b/modules/rkt/rkt-fbp/msg.rkt
@@ -5,6 +5,12 @@
 (struct msg-set-scheduler-thread ([t : Thread]))
 (struct msg-add-agent ([type : String] [name : String]))
 (struct msg-connect ([out : String][port-out : String][in : String][port-in : String]))
+(struct msg-connect-array-to ([out : String][port-out : String][selection : String]
+                                            [in : String][port-in : String]))
+(struct msg-connect-to-array ([out : String][port-out : String]
+                                            [in : String][port-in : String][selection : String]))
+(struct msg-connect-array-to-array ([out : String][port-out : String][selection-out : String]
+                                            [in : String][port-in : String][selection-in : String]))
 (struct msg-iip ([agt : String][port : String][iip : Any]))
 (struct msg-inc-ip ([agt : String]))
 (struct msg-dec-ip ([agt : String]))
@@ -16,6 +22,9 @@
 (define-type Msg (U msg-set-scheduler-thread
                     msg-add-agent
                     msg-connect
+                    msg-connect-array-to
+                    msg-connect-to-array
+                    msg-connect-array-to-array
                     msg-iip
                     msg-inc-ip
                     msg-dec-ip

--- a/modules/rkt/rkt-fbp/msg.rkt
+++ b/modules/rkt/rkt-fbp/msg.rkt
@@ -11,6 +11,7 @@
 (struct msg-run-end ([agt : String]))
 (struct msg-display ())
 (struct msg-quit ())
+(struct msg-stop ())
 (struct msg-run ([agt : String]))
 (define-type Msg (U msg-set-scheduler-thread
                     msg-add-agent
@@ -21,4 +22,5 @@
                     msg-run-end
                     msg-display
                     msg-quit
+                    msg-stop
                     msg-run))

--- a/modules/rkt/rkt-fbp/scheduler.rkt
+++ b/modules/rkt/rkt-fbp/scheduler.rkt
@@ -47,11 +47,8 @@
               [new-outport (hash-set old-outport port-out port)]
               [new-out-agt (struct-copy agent out-agt [outport new-outport])]
               [new-agent-state (struct-copy agent-state out-agt-state [state new-out-agt])]
-              [new-agents (hash-set agents out new-agent-state)]
-              )
-         (scheduler-loop (struct-copy scheduler self [agents new-agents]))
-         )
-       ]
+              [new-agents (hash-set agents out new-agent-state)])
+         (scheduler-loop (struct-copy scheduler self [agents new-agents])))]
       [(msg-iip agt port iip)
        (let* ([agents (scheduler-agents self)]
               [in-agt-state (hash-ref agents agt)]
@@ -68,8 +65,7 @@
               [new-agents (hash-set agents agt new-agt-state)]
               [new-self (struct-copy scheduler self [agents new-agents])])
          ; Increase number of saved IP
-         (scheduler-loop (exec-agent new-self agt))
-       )]
+         (scheduler-loop (exec-agent new-self agt)))]
       [(msg-dec-ip agt)
        (let* ([agents (scheduler-agents self)]
               [agt-state (hash-ref agents agt)]
@@ -77,8 +73,7 @@
               [new-agt-state (struct-copy agent-state agt-state [number-ips (- nbr 1)])]
               [new-agents (hash-set agents agt new-agt-state)]
               [new-self (struct-copy scheduler self [agents new-agents])])
-         (scheduler-loop new-self)
-         )]
+         (scheduler-loop new-self))]
       [(msg-run-end agt-name)
        (let* ([agents (scheduler-agents self)]
               [nbr-running (scheduler-number-running self)]
@@ -92,22 +87,15 @@
               [stop? (scheduler-will-stop new-state)])
          (if (and stop? (= nbr-running 0))
              (void)
-             (scheduler-loop new-state)
-             )
-         )
-       ]
+             (scheduler-loop new-state)))]
       [(msg-stop)
        (if (= (scheduler-number-running self) 0)
            (void)
-           (scheduler-loop (struct-copy scheduler self [will-stop #t]))
-           )]
+           (scheduler-loop (struct-copy scheduler self [will-stop #t])))]
       [(msg-display) (displayln self) (scheduler-loop self)]
       [(msg-quit) (displayln "Scheduler shut down")]
       [else (display "unknown msg : ") (displayln msg)
-            (scheduler-loop self)]
-      )
-    )
-  )
+            (scheduler-loop self)])))
 
 (: exec-agent (-> scheduler String scheduler))
 (define (exec-agent state agt-name)
@@ -138,15 +126,10 @@
 (: make-scheduler (-> False (-> Msg Void)))
 (define (make-scheduler opt)
   (let* ([state (scheduler #hash() 0 #f (thread (lambda() (void))))]
-         [t (thread (lambda() (scheduler-loop state)))]
-         )
+         [t (thread (lambda() (scheduler-loop state)))])
     (thread-send t (msg-set-scheduler-thread t))
     (lambda (msg)
       (thread-send t msg)
       (match msg
         [(msg-stop) (thread-wait t)]
-        [else (void)])
-      )
-    )
-  )
-
+        [else (void)]))))


### PR DESCRIPTION
This PR solved two problems : Halt and Array port. Also, there are two little fix (useless field and styling).

The scheduler can now halt when all the agents are not running (see commit b02b255 ).

The agent and the scheduler can now manage array ports (see commit 6977351 for example).
The next step will to provide helper function to send and receive from array port.
