### PR TITLE
No racket scheduler #128

### DIFF
--- a/modules/rkt/rkt-fbp/agents/fvm/get-path.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/get-path.rkt
@@ -1,0 +1,17 @@
+#lang racket/base
+
+(provide agt)
+
+(require fractalide/modules/rkt/rkt-fbp/agent)
+(require fractalide/modules/rkt/rkt-fbp/graph)
+
+
+(define agt (define-agent
+              #:input '("in")
+              #:output '("out")
+              #:proc (lambda (input output input-array output-array option)
+                       (let* ([agt (recv (input "in"))])
+                         (define new-type (string-append "agents/" (g-agent-type agt) ".rkt"))
+                         (define new-agent (struct-copy g-agent agt
+                                                        [type new-type]))
+                           (send (output "out") new-agent)))))

--- a/modules/rkt/rkt-fbp/agents/fvm/load-graph.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/load-graph.rkt
@@ -59,7 +59,8 @@
     (if (empty? not-visited)
         (resolve-virtual virtual-in virtual-out actual-graph)
         (let* ([next (car not-visited)]
-              [is-subnet? (dynamic-require (g-agent-type next) 'g (lambda () #f))])
+               [next (begin (send (output "ask-path") next) (recv (input "ask-path")))]
+               [is-subnet? (dynamic-require (g-agent-type next) 'g (lambda () #f))])
           (if is-subnet?
               ; It's a sub-graph. Get the new graph, add the nodes in not-visited, save the virtual port and save the rest of the graph
               (let* ([new-graph (get-graph next input output)]
@@ -79,8 +80,8 @@
   (rec-flat-graph (graph-agent actual-graph) '() '() (struct-copy graph actual-graph [agent '()])))
 
 (define agt (define-agent
-              #:input '("in" "ask-graph")
-              #:output '("out" "ask-graph")
+              #:input '("in" "ask-path" "ask-graph")
+              #:output '("out" "ask-path" "ask-graph")
               #:proc (lambda (input output input-array output-array option)
                        (let* ([msg (recv (input "in"))])
                          (define flat (flat-graph msg input output))

--- a/modules/rkt/rkt-fbp/agents/gui/horizontal-panel.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/horizontal-panel.rkt
@@ -34,6 +34,8 @@
                        (if msg-in
                            ; A message in the input port
                            (match msg-in
+                             [(vector "set-orientation" orientation)
+                              (class-send hp set-orientation orientation)]
                              [else (send-action output output-array msg-in)])
                            ; At least a message in the input array port
                            (for ([(place containee) (input-array "place")])

--- a/modules/rkt/rkt-fbp/agents/gui/vertical-panel.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/vertical-panel.rkt
@@ -1,0 +1,12 @@
+#lang racket/base
+
+(provide g)
+
+(require fractalide/modules/rkt/rkt-fbp/graph)
+
+(define g (make-graph (list
+                       (add-agent "panel" "gui/horizontal-panel")
+                       (iip "panel" "in" (vector "set-orientation" #f))
+                       (virtual-in "in" "panel" "in")
+                       (virtual-in "place" "panel" "place")
+                       (virtual-out "out" "panel" "out"))))

--- a/modules/rkt/rkt-fbp/agents/math/and.rkt
+++ b/modules/rkt/rkt-fbp/agents/math/and.rkt
@@ -5,8 +5,8 @@
 (require fractalide/modules/rkt/rkt-fbp/graph)
 
 (define g (make-graph (list
-                       (add-agent "nand" "agents/math/nand.rkt")
-                       (add-agent "clone" "agents/clone.rkt")
+                       (add-agent "nand" "math/nand")
+                       (add-agent "clone" "clone")
                        (connect "clone" "out" "1" "nand" "x" #f)
                        (connect "clone" "out" "2" "nand" "y" #f)
                        (virtual-in "in" "clone" "in")

--- a/modules/rkt/rkt-fbp/agents/test.rkt
+++ b/modules/rkt/rkt-fbp/agents/test.rkt
@@ -5,9 +5,9 @@
 (require fractalide/modules/rkt/rkt-fbp/graph)
 
 (define g (make-graph (list
-                       (add-agent "nand" "agents/math/nand.rkt")
-                       (add-agent "and" "agents/math/and.rkt")
-                       (add-agent "disp" "agents/displayer.rkt")
+                       (add-agent "nand" "math/nand")
+                       (add-agent "and" "math/and")
+                       (add-agent "disp" "displayer")
                        (connect "and" "res" #f "disp" "in" #f)
                        (connect "nand" "res" #f "and" "in" #f)
                        (connect "nand" "res" #f "disp" "in" #f)

--- a/modules/rkt/rkt-fbp/agents/test/main.rkt
+++ b/modules/rkt/rkt-fbp/agents/test/main.rkt
@@ -6,9 +6,12 @@
 
 (define g (make-graph (list
                        (add-agent "frame" "gui/frame")
+                       ; VP
+                       (add-agent "vp" "gui/vertical-panel")
+                       (connect "vp" "out" #f "frame" "in" #f)
                        ; HP
                        (add-agent "hp" "gui/horizontal-panel")
-                       (connect "hp" "out" #f "frame" "in" #f)
+                       (connect "hp" "out" #f "vp" "place" 2)
                        ; Msg, button, ...
                        (add-agent "button" "gui/button")
                        (add-agent "msg" "gui/message")
@@ -32,7 +35,7 @@
                        (add-agent "but-quit" "gui/button")
                        (add-agent "ip-to-close" "test/to-close")
                        (connect "but-quit" "out" "button-clicked" "ip-to-close" "in" #f)
-                       (connect "but-quit" "out" #f "frame" "in" #f)
+                       (connect "but-quit" "out" #f "vp" "place" 1)
                        (connect "ip-to-close" "out" #f "frame" "in" #f)
                        (iip "but-quit" "in" (vector "set-label" "Close"))
                        )))

--- a/modules/rkt/rkt-fbp/agents/test/main.rkt
+++ b/modules/rkt/rkt-fbp/agents/test/main.rkt
@@ -5,17 +5,17 @@
 (require fractalide/modules/rkt/rkt-fbp/graph)
 
 (define g (make-graph (list
-                       (add-agent "frame" "agents/gui/frame.rkt")
+                       (add-agent "frame" "gui/frame")
                        ; HP
-                       (add-agent "hp" "agents/gui/horizontal-panel.rkt")
+                       (add-agent "hp" "gui/horizontal-panel")
                        (connect "hp" "out" #f "frame" "in" #f)
                        ; Msg, button, ...
-                       (add-agent "button" "agents/gui/button.rkt")
-                       (add-agent "msg" "agents/gui/message.rkt")
-                       (add-agent "msg2" "agents/gui/message.rkt")
-                       (add-agent "acc" "agents/test/accumulator.rkt")
+                       (add-agent "button" "gui/button")
+                       (add-agent "msg" "gui/message")
+                       (add-agent "msg2" "gui/message")
+                       (add-agent "acc" "test/accumulator")
                        ; For halting
-                       (add-agent "halt" "agents/halter.rkt")
+                       (add-agent "halt" "halter")
                        (connect "frame" "halt" #f "halt" "in" #f)
                        (iip "halt" "in" #f)
                        ; Connect everything
@@ -29,8 +29,8 @@
                        (iip "button" "in" (vector "set-label" "Click me!!"))
                        (iip "acc" "acc" 0)
                        ; Quit button
-                       (add-agent "but-quit" "agents/gui/button.rkt")
-                       (add-agent "ip-to-close" "agents/test/to-close.rkt")
+                       (add-agent "but-quit" "gui/button")
+                       (add-agent "ip-to-close" "test/to-close")
                        (connect "but-quit" "out" "button-clicked" "ip-to-close" "in" #f)
                        (connect "but-quit" "out" #f "frame" "in" #f)
                        (connect "ip-to-close" "out" #f "frame" "in" #f)

--- a/modules/rkt/rkt-fbp/main.rkt
+++ b/modules/rkt/rkt-fbp/main.rkt
@@ -9,6 +9,7 @@
 (sched (msg-add-agent "sched" "agents/fvm/scheduler.rkt"))
 (sched (msg-add-agent "load-graph" "agents/fvm/load-graph.rkt"))
 (sched (msg-add-agent "get-graph" "agents/fvm/get-graph.rkt"))
+(sched (msg-add-agent "get-path" "agents/fvm/get-path.rkt"))
 (sched (msg-add-agent "fvm" "agents/fvm/fvm.rkt"))
 (sched (msg-add-agent "halt" "agents/halter.rkt"))
 (sched (msg-connect "fvm" "sched" "sched" "in"))
@@ -17,6 +18,8 @@
 (sched (msg-connect "load-graph" "out" "fvm" "flat"))
 (sched (msg-connect "load-graph" "ask-graph" "get-graph" "in"))
 (sched (msg-connect "get-graph" "out" "load-graph" "ask-graph"))
+(sched (msg-connect "load-graph" "ask-path" "get-path" "in"))
+(sched (msg-connect "get-path" "out" "load-graph" "ask-path"))
 
 (sched (msg-iip "sched" "acc" (make-scheduler #f)))
 (sched (msg-iip "halt" "in" #f))


### PR DESCRIPTION
This PR does two things : 
- Add a 'get-path' agent. It allows to specify only the type of the agent, and not the path. The agent is responsible to make the correct translation (it will be possible to call `nix-env -i ...`here)
- Add the vertical-panel here