### PR TITLE
Problem: ${ makes styx trip up itself

### DIFF
--- a/HOWTO.adoc
+++ b/HOWTO.adoc
@@ -231,11 +231,11 @@ subgraph {
   src = ./.;
   flowscript = with nodes; with edges; &#x27;&#x27;
     db_path => db_path get_sql()
-    input => input id(${todo_get_id}) id -> get get_sql(${sqlite_local_get})
-    get_sql() id -> id todo_build_json(${todo_build_json})
+    input => input id(&#x24;{todo_get_id}) id -> get get_sql(&#x24;{sqlite_local_get})
+    get_sql() id -> id todo_build_json(&#x24;{todo_build_json})
     get_sql() response -> todo todo_build_json()
-    id() req_id -> id todo_add_req_id(${todo_add_req_id})
-    todo_build_json() json -> playload build_resp(${todo_build_response})
+    id() req_id -> id todo_add_req_id(&#x24;{todo_add_req_id})
+    todo_build_json() json -> playload build_resp(&#x24;{todo_build_response})
     get_sql() error -> error build_resp()
     build_resp() response -> response todo_add_req_id() response => response
    &#x27;&#x27;;
@@ -279,12 +279,12 @@ subgraph {
   src = ./.;
   flowscript = with nodes; with edges; &#x27;&#x27;
     db_path => db_path insert_todo()
-    input => input todo_get_todo(${todo_get_todo}) todo -> input cl_todo(${msg_clone})
-    cl_todo() clone[0] -> insert insert_todo(${sqlite_local_insert})
-    cl_todo() clone[1] -> todo todo_build_json(${todo_build_json})
+    input => input todo_get_todo(&#x24;{todo_get_todo}) todo -> input cl_todo(&#x24;{msg_clone})
+    cl_todo() clone[0] -> insert insert_todo(&#x24;{sqlite_local_insert})
+    cl_todo() clone[1] -> todo todo_build_json(&#x24;{todo_build_json})
     insert_todo() response -> id todo_build_json()
-    todo_get_todo() req_id -> id todo_add_req_id(${todo_add_req_id})
-    todo_build_json() json -> playload todo_build_response(${todo_build_response})
+    todo_get_todo() req_id -> id todo_add_req_id(&#x24;{todo_add_req_id})
+    todo_build_json() json -> playload todo_build_response(&#x24;{todo_build_response})
     todo_build_response() response -> response todo_add_req_id() response => response
    &#x27;&#x27;;
 }
@@ -323,11 +323,11 @@ image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images
 subgraph {
   src = ./.;
   flowscript = with nodes; with edges; &#x27;&#x27;
-    input => input id(${todo_get_id})
+    input => input id(&#x24;{todo_get_id})
     db_path => db_path delete_sql()
-    id() id -> delete delete_sql(${sqlite_local_delete})
-    delete_sql() response -> playload build_resp(${todo_build_response})
-    id() req_id -> id todo_add_req_id(${todo_add_req_id})
+    id() id -> delete delete_sql(&#x24;{sqlite_local_delete})
+    delete_sql() response -> playload build_resp(&#x24;{todo_build_response})
+    id() req_id -> id todo_add_req_id(&#x24;{todo_add_req_id})
     build_resp() response -> response todo_add_req_id() response => response
    &#x27;&#x27;;
 }
@@ -378,17 +378,17 @@ image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images
 subgraph {
   src = ./.;
   flowscript = with nodes; with edges; &#x27;&#x27;
-    input => input todo_get_todo(${todo_get_todo})
+    input => input todo_get_todo(&#x24;{todo_get_todo})
     db_path => db_path patch_sql()
-    todo_get_todo() id -> get get_sql(${sqlite_local_get})
-    synch(${todo_patch_synch})
-    get_sql() response -> todo synch() todo -> old merge(${todo_patch_json})
+    todo_get_todo() id -> get get_sql(&#x24;{sqlite_local_get})
+    synch(&#x24;{todo_patch_synch})
+    get_sql() response -> todo synch() todo -> old merge(&#x24;{todo_patch_json})
     todo_get_todo() raw_todo -> raw_todo synch() raw_todo -> new merge()
-    get_sql() id -> id synch() id -> id patch_sql(${sqlite_local_patch})
+    get_sql() id -> id synch() id -> id patch_sql(&#x24;{sqlite_local_patch})
     merge() todo -> msg patch_sql()
-    patch_sql() response -> playload build_resp(${todo_build_response})
+    patch_sql() response -> playload build_resp(&#x24;{todo_build_response})
     get_sql() error -> error synch() error -> error build_resp()
-    todo_get_todo() req_id -> id todo_add_req_id(${todo_add_req_id})
+    todo_get_todo() req_id -> id todo_add_req_id(&#x24;{todo_add_req_id})
     build_resp() response -> response todo_add_req_id() response => response
    &#x27;&#x27;;
 }

--- a/doc/quick-start.adoc
+++ b/doc/quick-start.adoc
@@ -249,15 +249,15 @@ Then insert the below into `default.nix`:
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    input => input clone(${msg_clone})
-    clone() clone[1] -> a nand(${maths_boolean_nand}) output => output
+    input => input clone(&#x24;{msg_clone})
+    clone() clone[1] -> a nand(&#x24;{maths_boolean_nand}) output => output
     clone() clone[2] -> b nand()
   &#x27;&#x27;;
 }
 
 ----
 
-Notice the `${maths_boolean_nand}` and `${msg_clone}`. Nix will replace these with fully qualified paths to the compiled `agents` at compile time. `msg_clone` is a different `agent`, you may reference the source code at `nodes/rs/msg/clone`.
+Notice the `&#x24;{maths_boolean_nand}` and `&#x24;{msg_clone}`. Nix will replace these with fully qualified paths to the compiled `agents` at compile time. `msg_clone` is a different `agent`, you may reference the source code at `nodes/rs/msg/clone`.
 
 
 * Add your new NOT `subgraph` to the `nodes/rs/default.nix`
@@ -297,7 +297,7 @@ clone() clone[1] -> a nand(/nix/store/bi0jacqxz1az1bbrc8470jbl7z3cmwdn-maths_boo
 clone() clone[2] -> b nand()
 ----
 
-Notice the `${maths_boolean_nand}` and `${msg_clone}` were replaced with fully qualified paths. This output is meant for the `fvm` (Fractalide Virtual Machine) to parse and isn't meant to be edited by humans.
+Notice the `&#x24;{maths_boolean_nand}` and `&#x24;{msg_clone}` were replaced with fully qualified paths. This output is meant for the `fvm` (Fractalide Virtual Machine) to parse and isn't meant to be edited by humans.
 
 * Let us prepare to run our new `NOT` component. This is where we create `imsgs` which contain the actual values to be passed into the `NOT` gate.
 
@@ -318,7 +318,7 @@ in
 subgraph {
  src = ./.;
  flowscript = with nodes.rs; &#x27;&#x27;
-  '${PrimBool}' -> input not(${maths_boolean_not}) output -> input io_print(${maths_boolean_print})
+  '&#x24;{PrimBool}' -> input not(&#x24;{maths_boolean_not}) output -> input io_print(&#x24;{maths_boolean_print})
  &#x27;&#x27;;
 }
 ----

--- a/edges/README.adoc
+++ b/edges/README.adoc
@@ -30,7 +30,7 @@ When developing a `subgraph` there comes a time when the developer wants to inje
 subgraph {
   src = ./.;
   flowscript = with nodes; with edges; &#x27;&#x27;
-    '${prim_bool}:(boolean=true)' -> INPUT_PORT NAME()
+    '&#x24;{prim_bool}:(boolean=true)' -> INPUT_PORT NAME()
   &#x27;&#x27;;
 }
 ----
@@ -142,7 +142,7 @@ edge {
   edges = with edges; [ command ];
   schema = with edges; &#x27;&#x27;
     @0xf61e7fcd2b18d862;
-    using Command = import "${command}/src/edge.capnp";
+    using Command = import "&#x24;{command}/src/edge.capnp";
     struct ListCommand {
         commands @0 :List(Command.Command);
     }
@@ -220,7 +220,7 @@ edge {
   edges = with edges; [ command ];
   schema = with edges; &#x27;&#x27;
     @0xf61e7fcd2b18d862;
-    using CommandInstanceName = import "${command}/src/edge.capnp";
+    using CommandInstanceName = import "&#x24;{command}/src/edge.capnp";
     struct ListCommand {
         commands @0 :List(CommandInstanceName.Command);
     }
@@ -229,7 +229,7 @@ edge {
 ----
 
 You must pull explicitly mention the `edge` you want to import via the `  edges = with edges; [ command ];`
-Then you must `import` it via this mechanism: `using CommandInstanceName = import "${command}/src/edge.capnp";`
+Then you must `import` it via this mechanism: `using CommandInstanceName = import "&#x24;{command}/src/edge.capnp";`
 and lastly use it `... commands @0 :List(CommandInstanceName.Command); ...`
 
 Out of curiosity what does the output of the above `list_command` `contract` function look like?

--- a/nodes/README.adoc
+++ b/nodes/README.adoc
@@ -64,10 +64,10 @@ in
 subgraph {
   src = ./.;
   flowscript = with nodes.rs;&#x27;&#x27;
-    nand(${maths_boolean_nand})
-    '${imsgTrue}' -> a nand()
-    '${imsgTrue}' -> b nand()
-    nand() output -> input io_print(${maths_boolean_print})
+    nand(&#x24;{maths_boolean_nand})
+    '&#x24;{imsgTrue}' -> a nand()
+    '&#x24;{imsgTrue}' -> b nand()
+    nand() output -> input io_print(&#x24;{maths_boolean_print})
   &#x27;&#x27;;
 }
 ----
@@ -78,7 +78,7 @@ image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images
 * The `subgraph` building function accepts these arguments:
 ** The `src` attribute is used to derive a `Subgraph` name based on location in the directory hierarchy.
 ** The `flowscript` attribute defines the business logic. Here data flowing through a system becomes a first class citizen that can be manipulated. `Nodes` and `Edges` are brought into scope between the opening &#x27;&#x27; and closing &#x27;&#x27; double single quotes by using the `with nodes; with edges;` syntax.
-* `Nix` assists us greatly, in that each `node` name (the stuff between the curly quotes ``${...}``) undergoes a compilation step resolving every name into an absolute `/path/to/compiled/lib.subgraph` text file and `/path/to/compiled/libagent.so` shared object.
+* `Nix` assists us greatly, in that each `node` name (the stuff between the curly quotes ``&#x24;{...}``) undergoes a compilation step resolving every name into an absolute `/path/to/compiled/lib.subgraph` text file and `/path/to/compiled/libagent.so` shared object.
 * This compilation is lazy and only referenced names will be compiled. In other words `Subgraph` could be a top level `Subgraph` of a many layer deep hierarchy and only referenced `Nodes` will be compiled in a lazy fashion, *not* the entire `fractalide/nodes` folder.
 
 This is the output of the above ``Subgraph``'s compilation:
@@ -122,7 +122,7 @@ image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    agent_name(${name_of_agent})
+    agent_name(&#x24;{name_of_agent})
   &#x27;&#x27;;
 }
 ----
@@ -138,7 +138,7 @@ image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    agent_name(${name_of_agent}) // <──┐
+    agent_name(&#x24;{name_of_agent}) // <──┐
     agent_name()                 // <──┴─ same instance
   &#x27;&#x27;;
 }
@@ -155,7 +155,7 @@ image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    agent1(${name_of_agent1}) output_port -> input_port agent2(${name_of_agent2})
+    agent1(&#x24;{name_of_agent1}) output_port -> input_port agent2(&#x24;{name_of_agent2})
   &#x27;&#x27;;
 }
 ----
@@ -178,7 +178,7 @@ in
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    '${imsgTrue}' -> a agent(${name_of_agent})
+    '&#x24;{imsgTrue}' -> a agent(&#x24;{name_of_agent})
   &#x27;&#x27;;
 }
 ----
@@ -200,8 +200,8 @@ in
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    td(${ui_js_nodes.flex})
-    '${UiJsCreate}' -> input td()
+    td(&#x24;{ui_js_nodes.flex})
+    '&#x24;{UiJsCreate}' -> input td()
   &#x27;&#x27;;
 }
 ----
@@ -220,7 +220,7 @@ image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    subgraph_input => input agent(${name_of_agent})
+    subgraph_input => input agent(&#x24;{name_of_agent})
   &#x27;&#x27;;
 }
 ----
@@ -236,7 +236,7 @@ image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    agent(${name_of_agent}) output => subgraph_output
+    agent(&#x24;{name_of_agent}) output => subgraph_output
   &#x27;&#x27;;
 }
 ----
@@ -252,7 +252,7 @@ image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    subgraph(${name_of_subgraph})
+    subgraph(&#x24;{name_of_subgraph})
   &#x27;&#x27;;
 }
 ----
@@ -268,8 +268,8 @@ image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    subgraph(${name_of_subgraph})
-    agent(${name_of_agent})
+    subgraph(&#x24;{name_of_subgraph})
+    agent(&#x24;{name_of_agent})
     subgraph() output -> input agent()
   &#x27;&#x27;;
 }
@@ -286,7 +286,7 @@ image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    db_path => input clone(${msg_clone})
+    db_path => input clone(&#x24;{msg_clone})
     clone() clone[0] => db_path0
     clone() clone[1] => db_path1
     clone() clone[2] => db_path2
@@ -308,7 +308,7 @@ NOTE: `clone[1]` is an `array output port` and in this particular `Subgraph` `Me
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    add0 => add[0] adder(${path_to_adder})
+    add0 => add[0] adder(&#x24;{path_to_adder})
     add1 => add[1] adder()
     add2 => add[2] adder()
     add3 => add[3] adder() output -> output
@@ -329,8 +329,8 @@ image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    input => input clone(${msg_clone})
-    clone() clone[0] -> a nand(${maths_boolean_nand})
+    input => input clone(&#x24;{msg_clone})
+    clone() clone[0] -> a nand(&#x24;{maths_boolean_nand})
     clone() clone[1] -> b nand() output => output
   &#x27;&#x27;;
 }
@@ -338,7 +338,7 @@ subgraph {
 
 image::https://raw.githubusercontent.com/fractalide/fractalide/master/doc/images/subnet_ex13.png[]
 
-The `Node` and `Edge` names, i.e.: `${maths_boolean_nand}` seem quite long. Fractalide uses a hierarchical naming scheme. So you can find the `maths_boolean_not` node by opening to the `nodes/rs/maths/boolean/not/default.nix` file. The whole goal of this is to avoid name shadowing among potentially hundreds to thousands of nodes.
+The `Node` and `Edge` names, i.e.: `&#x24;{maths_boolean_nand}` seem quite long. Fractalide uses a hierarchical naming scheme. So you can find the `maths_boolean_not` node by opening to the `nodes/rs/maths/boolean/not/default.nix` file. The whole goal of this is to avoid name shadowing among potentially hundreds to thousands of nodes.
 
 Explanation of the `Subgraph`:
 
@@ -360,10 +360,10 @@ in
 subgraph {
   src = ./.;
   flowscript = with nodes.rs; &#x27;&#x27;
-    '${imsgTrue}' -> a nand(${maths_boolean_nand})
-    '${imsgTrue}' -> b nand()
-    nand() output -> input not(${maths_boolean_not})
-    not() output -> input print(${maths_boolean_print})
+    '&#x24;{imsgTrue}' -> a nand(&#x24;{maths_boolean_nand})
+    '&#x24;{imsgTrue}' -> b nand()
+    nand() output -> input not(&#x24;{maths_boolean_not})
+    not() output -> input print(&#x24;{maths_boolean_print})
   &#x27;&#x27;;
 }
 ----
@@ -381,12 +381,12 @@ Notice we're using the `not` node implemented earlier. One can build hierarchies
 subgraph {
   src = ./.;
   flowscript = with nodes; with edges; &#x27;&#x27;
-    listen => listen http(${net_http_nodes.http})
-    db_path => input clone(${msg_clone})
-    clone() clone[1] -> db_path get(${app_todo_nodes.todo_get})
-    clone() clone[2] -> db_path post(${app_todo_nodes.todo_post})
-    clone() clone[3] -> db_path del(${app_todo_nodes.todo_delete})
-    clone() clone[4] -> db_path patch(${app_todo_nodes.todo_patch})
+    listen => listen http(&#x24;{net_http_nodes.http})
+    db_path => input clone(&#x24;{msg_clone})
+    clone() clone[1] -> db_path get(&#x24;{app_todo_nodes.todo_get})
+    clone() clone[2] -> db_path post(&#x24;{app_todo_nodes.todo_post})
+    clone() clone[3] -> db_path del(&#x24;{app_todo_nodes.todo_delete})
+    clone() clone[4] -> db_path patch(&#x24;{app_todo_nodes.todo_patch})
 
     http() GET[/todos/.+] -> input get() response -> response http()
     http() POST[/todos/?] -> input post() response -> response http()

--- a/nodes/rs/README.adoc
+++ b/nodes/rs/README.adoc
@@ -100,7 +100,7 @@ This is the output of the above ``agent``'s compilation:
 
 === The `agent!` Rust macro
 
-This is the heart of `Fractalide`. Everything revolves around this `API`. The below is an implementation of the `${maths_boolean_nand}` `agent` seen earlier.
+This is the heart of `Fractalide`. Everything revolves around this `API`. The below is an implementation of the `&#x24;{maths_boolean_nand}` `agent` seen earlier.
 
 [source, rust]
 ----


### PR DESCRIPTION
Probably only when `$` is preceded by a `'` (because it escapes the
`$` with a `''`, which then combined with the preceding `'` gets
interpreted as end of string), but might as well escape all dollars
before curlies.