### PR TITLE
Problem: |& fails on Travis darwin bash

### DIFF
--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -29,4 +29,4 @@ function subfold() {
   '
 }
 
-nix-build "$@" |& subfold ${!#}
+{ nix-build "$@" 2>&1; } | subfold ${!#}

--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -1,4 +1,5 @@
-#! /usr/bin/env bash
+#! /usr/bin/env nix-shell
+#! nix-shell -p bash coreutils gawk -i bash
 set -e
 set -u
 set -o pipefail
@@ -29,4 +30,4 @@ function subfold() {
   '
 }
 
-{ nix-build "$@" 2>&1; } | subfold ${!#}
+nix-build "$@" |& subfold ${!#}

--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -p bash coreutils gawk -i bash
+#! nix-shell --quiet -p bash coreutils gawk -i bash
 set -e
 set -u
 set -o pipefail


### PR DESCRIPTION
Solution: Use 2>&1 before pipe instead.