### PR TITLE
Problem: travis darwin rebuilds Nix

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2,8 +2,8 @@
 , pkgs ? import (bootPkgs.fetchFromGitHub {
     owner  = "NixOS";
     repo   = "nixpkgs";
-    rev    = "d91caac6c3e58b8a5f4721c0a6cc8f0dc3b93fd3";
-    sha256 = "1x19607ypfcdz0i5aims4cbi2ca7dm0d8jyar46knv0nqx8kly0s";
+    rev    = "9d0b6b9dfc92a2704e2111aa836f5bdbf8c9ba42";
+    sha256 = "096r7ylnwz4nshrfkh127dg8nhrcvgpr69l4xrdgy3kbq049r3nb";
   })
 , fetchFromGitHub ? (pkgs {}).fetchFromGitHub
 , rustOverlay ? fetchFromGitHub {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -13,8 +13,8 @@
     sha256 = "1shz56l19kgk05p2xvhb7jg1whhfjix6njx1q4rvrc5p1lvyvizd";
   }
 , racket2nix ? import (fetchFromGitHub {
-    owner  = "clacke";
-    repo   = "racket2nix-clacke";
+    owner  = "fractalide";
+    repo   = "racket2nix";
     rev    = "622cb6c52fe59b82dea88ec75a2d5d2a98e408b6";
     sha256 = "1qvfrab24zsm1ygnqcin9vjqv63a0swqiwdr3im8f2v2kciklwkx";
   }) { racket = (pkgs {}).racket-minimal; }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -13,10 +13,10 @@
     sha256 = "1shz56l19kgk05p2xvhb7jg1whhfjix6njx1q4rvrc5p1lvyvizd";
   }
 , racket2nix ? import (fetchFromGitHub {
-    owner  = "fractalide";
-    repo   = "racket2nix";
-    rev    = "f694823e1bf959a11f717e60b4e95bc0185f4fc0";
-    sha256 = "1b1gwbjp91i555dy18shfyfsp272qdwhqi72pzl09lfl14d5z37r";
+    owner  = "clacke";
+    repo   = "racket2nix-clacke";
+    rev    = "622cb6c52fe59b82dea88ec75a2d5d2a98e408b6";
+    sha256 = "1qvfrab24zsm1ygnqcin9vjqv63a0swqiwdr3im8f2v2kciklwkx";
   }) { racket = (pkgs {}).racket-minimal; }
 }:
 pkgs {


### PR DESCRIPTION
Solution: Bump racket2nix to a rev where the Nix of the pinned nixpkgs is still in Hydra cache.

Also bump our nixpkgs to the same rev, so we only download nixpkgs once.