### PR TITLE
Problem: load-graph can accept only relative paths

### DIFF
--- a/modules/rkt/rkt-fbp/agents/fvm/get-path.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/get-path.rkt
@@ -5,15 +5,20 @@
 (require fractalide/modules/rkt/rkt-fbp/agent)
 (require fractalide/modules/rkt/rkt-fbp/graph)
 
-(define (interpolated-by-nix? type)
-  (define dot-path (regexp-match #px"\\$\\{(.*)\\}" type))
-  (if (equal? (substring type 0 2) "${")
-      ; it's not interpolated nix code
-      (string-append "agents/"
-                     (string-trim
-                      (string-replace (cadr dot-path) "." "/")) ".rkt")
-      ; nix has interpolated it, use the path as is
-      type))
+(define (maybe-nix-string->module-path-or-passthrough type)
+  (cond
+    ; Fully processed, ready for dynamic-require
+    [((or/c module-path? resolved-module-path? module-path-index?) type) type]
+    ; Needs processing, transform into relative path
+    [(equal? (substring type 0 2) "${")
+     (define dot-path (regexp-match #px"\\$\\{(.*)\\}" type))
+     (string-append "agents/"
+                    (string-trim
+                      (string-replace (cadr dot-path) "." "/")) ".rkt")]
+    [else
+     (raise-argument-error 'get-path
+                           "type required to be a nix interpolation string or something recognized by dynamic-require"
+                           type)]))
 
 (define agt
   (define-agent
@@ -22,7 +27,7 @@
     #:proc
     (lambda (input output input-array output-array)
       (let* ([agt (recv (input "in"))])
-        (define new-type (interpolated-by-nix? (g-agent-type agt)))
+        (define new-type (maybe-nix-string->module-path-or-passthrough (g-agent-type agt)))
         (define new-agent (struct-copy g-agent agt
                                        [type new-type]))
         (send (output "out") new-agent)))))


### PR DESCRIPTION
We need to be able to send full system paths.

If you do `add-graph` with a graph with a node having `(make-resolved-module-path "/nix/store/.../blah.rkt")` as an agent path, the `substring` call shouts, insisting it receive a string.

Solution: If get-path receives anything that is processed enough for
dynamic-require, just pass it through.

This allows app setup to resolve paths, using Nix or otherwise, and
have fvm accept them.