### PR TITLE
 Problem: agents are loaded relative to current directory 

### DIFF
--- a/modules/rkt/rkt-fbp/agents/fvm/get-graph.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/get-graph.rkt
@@ -17,7 +17,7 @@
              [name (g-agent-name agt)]
              [type (g-agent-type agt)])
         ; retrieve the graph struct
-        (define g (dynamic-require-agent type 'g))
+        (define g (load-graph type))
         ; rename the subgraph
         (let ([new-agent
                (for/list ([agent (graph-agent g)])

--- a/modules/rkt/rkt-fbp/agents/fvm/get-graph.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/get-graph.rkt
@@ -3,6 +3,7 @@
 (provide agt)
 
 (require fractalide/modules/rkt/rkt-fbp/agent)
+(require fractalide/modules/rkt/rkt-fbp/loader)
 (require fractalide/modules/rkt/rkt-fbp/graph)
 
 
@@ -16,7 +17,7 @@
              [name (g-agent-name agt)]
              [type (g-agent-type agt)])
         ; retrieve the graph struct
-        (define g (dynamic-require type 'g))
+        (define g (dynamic-require-agent type 'g))
         ; rename the subgraph
         (let ([new-agent
                (for/list ([agent (graph-agent g)])

--- a/modules/rkt/rkt-fbp/agents/fvm/get-path.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/get-path.rkt
@@ -12,9 +12,7 @@
     ; Needs processing, transform into relative path
     [(equal? (substring type 0 2) "${")
      (define dot-path (regexp-match #px"\\$\\{(.*)\\}" type))
-     (string-append "agents/"
-                    (string-trim
-                      (string-replace (cadr dot-path) "." "/")) ".rkt")]
+     (string->symbol (string-trim (string-replace (cadr dot-path) "." "/")))]
     [else
      (raise-argument-error 'get-path
                            "type required to be a nix interpolation string or something recognized by dynamic-require"

--- a/modules/rkt/rkt-fbp/agents/fvm/load-graph.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/load-graph.rkt
@@ -21,7 +21,7 @@
         ; False -> Visit the next node
         (let* ([next (car not-visited)]
                [next (begin (send (output "ask-path") next) (recv (input "ask-path")))]
-               [is-subnet? (dynamic-require-agent (g-agent-type next) 'g (lambda () #f))])
+               [is-subnet? (load-graph (g-agent-type next) (lambda () #f))])
           (if is-subnet?
               ; It's a sub-graph. Get the new graph, add the nodes in not-visited, save the virtual port and save the rest of the graph
               (let* ([new-graph (get-graph next input output)]

--- a/modules/rkt/rkt-fbp/agents/fvm/load-graph.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/load-graph.rkt
@@ -4,6 +4,7 @@
 
 (require racket/list)
 (require fractalide/modules/rkt/rkt-fbp/agent)
+(require fractalide/modules/rkt/rkt-fbp/loader)
 (require fractalide/modules/rkt/rkt-fbp/graph)
 
 ; (-> agent graph)
@@ -20,7 +21,7 @@
         ; False -> Visit the next node
         (let* ([next (car not-visited)]
                [next (begin (send (output "ask-path") next) (recv (input "ask-path")))]
-               [is-subnet? (dynamic-require (g-agent-type next) 'g (lambda () #f))])
+               [is-subnet? (dynamic-require-agent (g-agent-type next) 'g (lambda () #f))])
           (if is-subnet?
               ; It's a sub-graph. Get the new graph, add the nodes in not-visited, save the virtual port and save the rest of the graph
               (let* ([new-graph (get-graph next input output)]

--- a/modules/rkt/rkt-fbp/loader.rkt
+++ b/modules/rkt/rkt-fbp/loader.rkt
@@ -1,6 +1,8 @@
 #lang racket/base
 
-(provide load-agent dynamic-require-agent)
+(provide dynamic-require-agent
+         load-agent
+         load-graph)
 
 (define (dynamic-require-agent agt provided (fail-thunk #f))
   (define (try-dynamic-require mod provided fail-thunk fallback)
@@ -17,3 +19,5 @@
       (try-dynamic-require agt provided fail-thunk (lambda (e) (raise e)))))
 
 (define (load-agent path) (dynamic-require-agent path 'agt))
+
+(define (load-graph path (fail-thunk #f)) (dynamic-require-agent path 'g fail-thunk))

--- a/modules/rkt/rkt-fbp/loader.rkt
+++ b/modules/rkt/rkt-fbp/loader.rkt
@@ -1,7 +1,19 @@
 #lang racket/base
 
-(provide load-agent)
+(provide load-agent dynamic-require-agent)
 
-(define (load-agent path)
-  (let ([agt (dynamic-require path 'agt)])
-    agt))
+(define (dynamic-require-agent agt provided (fail-thunk #f))
+  (define (try-dynamic-require mod provided fail-thunk fallback)
+    (with-handlers
+      ([exn:fail:filesystem:missing-module? fallback])
+      (if fail-thunk (dynamic-require mod provided fail-thunk)
+                     (dynamic-require mod provided))))
+  (if (symbol? agt)
+      (try-dynamic-require agt provided fail-thunk (lambda (e)
+        (try-dynamic-require (string->symbol (string-append
+          "fractalide/modules/rkt/rkt-fbp/agents/"
+          (symbol->string agt)))
+          provided fail-thunk (lambda (_) (raise e)))))
+      (try-dynamic-require agt provided fail-thunk (lambda (e) (raise e)))))
+
+(define (load-agent path) (dynamic-require-agent path 'agt))

--- a/modules/rkt/rkt-fbp/scheduler.rkt
+++ b/modules/rkt/rkt-fbp/scheduler.rkt
@@ -8,6 +8,7 @@
 (require racket/match)
 (require racket/function)
 (require fractalide/modules/rkt/rkt-fbp/agent)
+(require fractalide/modules/rkt/rkt-fbp/loader)
 (require fractalide/modules/rkt/rkt-fbp/port)
 (require fractalide/modules/rkt/rkt-fbp/def)
 
@@ -23,7 +24,7 @@
   (match msg
       [(msg-add-agent name type)
        (let* ([path type]
-              [agt (dynamic-require path 'agt)]
+              [agt (load-agent path)]
               [agt (make-agent agt name (scheduler-mail-box self))]
               [old-agent (scheduler-agents self)]
               [agt-state (agent-state agt 0 #f)]


### PR DESCRIPTION
Solution: Make fvm capable of finding agents by collection path.

Make `${my.agent}` references use collection path instead of relative
file system path.

This is done by making agent references symbols, and providing a
fallback that looks for them in the agents collection context if the
global context fails. In this way we can have convenient short symbols
for our package-internal symbols, but external packages can use the
same mechanism to find their agents.