### PR TITLE
Problem: No place-holder in GUI

### DIFF
--- a/modules/rkt/rkt-fbp/agents/gui/choice.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/choice.rkt
@@ -43,7 +43,8 @@
                           [stretchable-width (hash-ref default 'stretchable-width)]
                           [stretchable-height (hash-ref default 'stretchable-height)]
                           [callback (lambda (button event)
-                                      (send (input "in") (cons (class:send event get-event-type) event)))])])
+                                      (send (input "in") (cons (class:send event get-event-type)
+                                                               (class:send button get-string-selection))))])])
       (send (input "acc") cb))))
 
 (define (process-msg msg widget input output output-array)

--- a/modules/rkt/rkt-fbp/agents/gui/place-holder.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/place-holder.rkt
@@ -1,0 +1,74 @@
+#lang racket/base
+
+(provide agt)
+
+(require fractalide/modules/rkt/rkt-fbp/agent
+         fractalide/modules/rkt/rkt-fbp/agents/gui/helper)
+
+
+(require racket/gui/base
+         racket/match
+         racket/list)
+(require (rename-in racket/class [send class-send]))
+
+(define (generate input)
+  (lambda (frame)
+    (let* ([ph (new panel% [parent frame])])
+      (send (input "acc") ph))))
+
+(define agt
+  (define-agent
+    #:input '("in") ; in port
+    #:input-array '("place")
+    #:output '("out") ; out port
+    #:output-array '("out")
+    #:proc
+    (lambda (input output input-array output-array)
+      (define acc (try-recv (input "acc")))
+      (define msg-in (try-recv (input "in")))
+      ; Init the first time
+      (define ph (if acc
+                     acc
+                     (begin
+                       (send (output "out") (cons 'init (generate input)))
+                       (cons (make-immutable-hash) (recv (input "acc"))))))
+
+      (if msg-in
+          ; TRUE : A message in the input port
+          (match msg-in
+            [else (send-action output output-array msg-in)])
+          ; FALSE : At least a message in the input array port
+          ; Change the accumulator ph with set!
+          (for ([(place containee) (input-array "place")])
+            (define msg (try-recv containee))
+            (if msg
+                (match msg
+                  [(cons 'init cont)
+                   (class-send (cdr ph) begin-container-sequence)
+                   ; Add it
+                   (cont (cdr ph))
+                   ; Get back the children, but no display
+                   (class-send (cdr ph) change-children
+                               (lambda (act)
+                                 ; get the new one
+                                 (define val (last act))
+                                 ; add it in the acc
+                                 (set! ph (cons (hash-set (car ph) place val)
+                                                (cdr ph)))
+                                 (if (> (length act) 1)
+                                     (list (car act))
+                                     '())))
+                   (class-send (cdr ph) end-container-sequence)]
+                  ; Drop the children, but no change in display
+                  [(cons 'delete #t)
+                   (set! ph (cons (hash-remove (car ph) place)
+                                  (cdr ph)))]
+                  ; Display a new children
+                  [(cons 'display #t)
+                   (class-send (cdr ph) change-children
+                               (lambda (_)
+                                 (list (hash-ref (car ph) place))))]
+                  [else (send-action output output-array msg)])
+                void)))
+
+      (send (output "acc") ph))))

--- a/modules/rkt/rkt-fbp/agents/test/main.rkt
+++ b/modules/rkt/rkt-fbp/agents/test/main.rkt
@@ -47,11 +47,6 @@
    (mesg "lb" "in" '(init . ((label . "a test: ")
                              (choices . ("42" "666" "1" "7"))
                              (columns . ("Number")))))
-   ; Choice
-   (node "choice" ${gui.choice})
-   (edge "choice" "out" _ "vp" "place" 13)
-   (mesg "choice" "in" '(init . ((label . "choice test: ")
-                                 (choices . ("1" "7" "42" "666")))))
    ; HP
    (node "hp" ${gui.horizontal-panel})
    (edge "hp" "out" _ "vp" "place" 3)
@@ -69,6 +64,27 @@
    (node "to-remove" "${test.to-remove}")
    (edge "but-rem" "out" 'button "to-remove" "in" _)
    (edge "to-remove" "out" _ "dynamic" "in" _)
+   ; Choice
+   (node "choice" ${gui.choice})
+   (edge "choice" "out" _ "vp" "place" 109)
+   (mesg "choice" "in" '(init . ((label . "Select your counter : ")
+                                 (choices . ("1" "2" "3")))))
+   ; Place-holder
+   (node "ph" ${gui.place-holder})
+   (edge "ph" "out" _ "vp" "place" 110)
+   (node "counter1" ${test.counter})
+   (node "counter2" ${test.counter})
+   (node "counter3" ${test.counter})
+   (edge "counter1" "out" _ "ph" "place" 1)
+   (edge "counter2" "out" _ "ph" "place" 2)
+   (edge "counter3" "out" _ "ph" "place" 3)
+   (mesg "counter1" "in" '(display . #t))
+   ; connection between choice and place-holder
+   (node "to-display" ${test.to-display})
+   (edge "choice" "out" 'choice "to-display" "in" _)
+   (edge "to-display" "out" "1" "counter1" "in" _)
+   (edge "to-display" "out" "2" "counter2" "in" _)
+   (edge "to-display" "out" "3" "counter3" "in" _)
    ; Quit button
    (node "but-quit" "${gui.button}")
    (node "ip-to-close" "${test.to-close}")

--- a/modules/rkt/rkt-fbp/agents/test/to-display.rkt
+++ b/modules/rkt/rkt-fbp/agents/test/to-display.rkt
@@ -1,0 +1,17 @@
+#lang racket/base
+
+(provide agt)
+
+(require racket/match
+         fractalide/modules/rkt/rkt-fbp/agent)
+
+(define agt
+  (define-agent
+    #:input '("in")
+    #:output-array '("out")
+    #:proc
+    (lambda (input output input-array output-array)
+      (let* ([msg (recv (input "in"))])
+        (match-define (cons 'choice num) msg)
+        (send (hash-ref (output-array "out") num) (cons 'display #t))
+        ))))


### PR DESCRIPTION
Solution: add it

This widget allows to choice between different sub-card to display.

All the children must be in the "place" input array port. Then, once created,
they can send the action `'(display . #t)` to be show in the place-holder. There
is only one children displayed at the time, and the creation doesn't show them.

```
(node "ph" ${gui.place-holder})
(node "1" ${a-card})
(node "2" ${a-card})
(mesg "1" "in" '(init . ...))
(mesg "2" "in" '(init . ...))
(mesg "1" "in" '(display . #t))
```
will display the "1" in the place-holder, and not "2" (even if this last one is
already created).

the message
```
(mesg "2" "in" '(display . #t))
```
will display the "2" and hide "1", but this last one is not deleted.

ie : in test/main.rkt, the `choice` widget allows to display a specific counter
between three.