### PR TITLE
Problem: require an edge was not nix friendly

### DIFF
--- a/modules/rkt/rkt-fbp/agents/fvm/fvm.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/fvm.rkt
@@ -4,11 +4,10 @@
 
 (require fractalide/modules/rkt/rkt-fbp/agent
          (prefix-in g: fractalide/modules/rkt/rkt-fbp/graph)
-         fractalide/modules/rkt/rkt-fbp/def)
+         fractalide/modules/rkt/rkt-fbp/def
+         racket/match)
 
-(require fractalide/modules/rkt/rkt-fbp/edges/fvm/dynamic-add)
-
-(require racket/match)
+(require/edge ${fvm.dynamic-add})
 
 ; TODO : manage well recursive virtual array (not all deleted for the moment)
 

--- a/modules/rkt/rkt-fbp/def.rkt
+++ b/modules/rkt/rkt-fbp/def.rkt
@@ -1,7 +1,11 @@
-#lang racket/base
+#lang racket
 
 (provide (all-defined-out)
          (struct-out agent))
+
+(require (for-syntax racket/syntax)
+         (for-syntax racket/string)
+         (for-syntax syntax/to-string))
 
 (struct agent (inport in-array-port outport out-array-port proc option))
 
@@ -33,3 +37,13 @@
 (struct msg-update-agent(agt proc))
 (struct msg-stop ())
 (struct msg-run (agt))
+
+; require/edge
+(define-syntax (require/edge stx)
+  (syntax-case stx ()
+    [(_ ${type})
+     (let ([transform (string->symbol (string-trim (string-replace (syntax->string #'(type)) "." "/")))])
+       (with-syntax ([type (format-id stx "fractalide/modules/rkt/rkt-fbp/edges/~a" transform)] )
+         #'(require type)))]
+    [(_ type)
+     #'(require type)]))


### PR DESCRIPTION
solution: add `(require/edge ...)`

Now, it is possible to use the macro `require/edge` in agent and graph.
It is designed as follow :
- `(require/edge ${fvm.dynamic-add}`
will look for `fractalide/modules/rkt/rkt-fbp/edges/fvm/dynamic-add`
- `(require/edge (file "/full/path/to/edge.rkt"))`
will load the full path.

So if there is no nix pre-processing, we will be in the former case.
If nix replace `${...}` by `(file "the/path)`, we will be in the second case.