### PR TITLE
Problem: not enough feedback when build fails

### DIFF
--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -41,4 +41,4 @@ function subfold() {
   '
 }
 
-nix-build "$@" |& subfold ${!#}
+nix-build --show-trace "$@" |& subfold ${!#}


### PR DESCRIPTION
Example: #198

Solution: Add --show-trace in nix-build-travis-fold.sh.

In the happy path, this does not affect readability. It only improves feedback when something fails.