### PR TITLE
Problem: nix cannot find nixpkgs.nix

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import nixpkgs.nix
+{ pkgs ? import ./nixpkgs.nix
 , fetchFromGitHub ? (pkgs {}).fetchFromGitHub
 , rustOverlay ? fetchFromGitHub {
     owner  = "mozilla";


### PR DESCRIPTION
Solution: nix needs a path ./nixpkgs.nix to find the file