### PR TITLE
Problem: default.nix is not suitable for hydra consumption

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,5 @@
+with import ./. {};
+
+[
+  pkgs.fractalide
+]


### PR DESCRIPTION
Solution: Create release.nix.

I have prepared Hydra to consume it already.