### PR TITLE
Problem: not testing against latest nixpkgs (also)

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -2,4 +2,9 @@ with import ./. {};
 
 {
   inherit (pkgs) fractalide;
+  fractalide-nixpkgs-unstable = let
+    nixpkgs = import ../nixpkgs;
+    pkgs = import pkgs { pkgs = nixpkgs; };
+  in
+    inherit (pkgs) fractalide;
 }


### PR DESCRIPTION
We should test against the latest nixpkgs to find out any incoming
issues before we bump.

Solution: Add fractalide-nixpkgs-unstable job.