### PR TITLE
Problem: can't inherit when not in an attrs context

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,5 +6,5 @@ with import ./. {};
     nixpkgs = import ../nixpkgs;
     pkgs = import pkgs { pkgs = nixpkgs; };
   in
-    inherit (pkgs) fractalide;
+    pkgs.fractalide;
 }


### PR DESCRIPTION
Solution: Just return the value.

 That's already inside the definition of an attribute.