### PR TITLE
Problem: ../nixpkgs is an incorrect way to refer to the other input

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,9 +1,9 @@
-with import ./. {};
+with import <fractalide> {};
 
 {
   inherit (pkgs) fractalide;
   fractalide-nixpkgs-unstable = let
-    nixpkgs = import ../nixpkgs;
+    nixpkgs = import <nixpkgs>;
     fractapkgs = import ./pkgs { pkgs = nixpkgs; };
   in
     fractapkgs.fractalide;


### PR DESCRIPTION
```
hydra-eval-jobs returned exit code 1:
error: while evaluating anonymous function at /nix/store/2hiihrivryavsa3srb1nr382frzszibk-git-export/pkgs/default.nix:1:1, called from /nix/store/2hiihrivryavsa3srb1nr382frzszibk-git-export/release.nix:7:18:
access to path '/nix/store/nixpkgs' is forbidden in restricted mode
```

So apparently we are in /nix/store/blah (probably blah ~= `*git-export*`) when the
expression runs.

I'm assuming the inputs are put in the NIX_PATH.

Solution: Refer to nixpkgs as `<nixpkgs>`.

To verify my assumption, refer to fractalide as `<fractalide>`.