### PR TITLE
Problem: hydra caches inputs

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -8,6 +8,7 @@
   }
 , racket2nix ? import ./racket2nix { racket = (pkgs {}).racket-minimal; }
 }:
+
 pkgs {
   overlays = [
     (import (builtins.toPath "${rustOverlay}/rust-overlay.nix"))


### PR DESCRIPTION
It will not rebuild the packages after I have made a nix-store --gc,
unless I force it to.

Solution: Make an inconsequential change.