### PR TITLE
Problem: Test definitions are repeating themselves

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,14 @@
 language: nix
 
+script:
+ - ./support/utils/nix-build-travis-fold.sh -I fractalide=. -A fractalide release.nix
+
 matrix:
   include:
     - os: linux
       dist: trusty
-      script:
-        #- ./support/utils/nix-build-travis-fold.sh tests
-        - ./support/utils/nix-build-travis-fold.sh -A pkgs.fractalide
     - os: linux
       dist: xenial
-      script:
-        #- ./support/utils/nix-build-travis-fold.sh tests
-        - ./support/utils/nix-build-travis-fold.sh -A pkgs.fractalide
     - os: linux
       dist: bionic
-      script:
-        #- ./support/utils/nix-build-travis-fold.sh tests
-        - ./support/utils/nix-build-travis-fold.sh -A pkgs.fractalide
     - os: osx
-      script:
-        - ./support/utils/nix-build-travis-fold.sh -A pkgs.fractalide


### PR DESCRIPTION
Solution: Define the test set entirely in release.nix.

Any exceptions to be made for e.g. darwin or certain Linux dists
should be done through nix, and with args to release.nix if
necessary.