### PR TITLE
Problem: not requiring signatures on substitutes

### DIFF
--- a/support/utils/setup-hydra.fractalide.com.sh
+++ b/support/utils/setup-hydra.fractalide.com.sh
@@ -20,7 +20,6 @@ touch $nix_conf
 substituters = $nixos_url $fracta_url
 trusted-substituters = $nixos_url $fracta_url
 trusted-public-keys = $nixos_key $fracta_key
-require-sigs = false
 EOF
 } > ${nix_conf}.new
 mv ${nix_conf}.new $nix_conf


### PR DESCRIPTION
fractalide/fractalide-infra#1 has been solved and we can now do this the right way.

Solution: Remove require-sigs = false from nix.conf patch.