### PR TITLE
Problem: we are not testing rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: nix
 
 script:
  - sudo env NIX_PATH=$NIX_PATH $(which nix-shell) ./support/utils/setup-hydra.fractalide.com.sh
- - [[ $(uname) == Linux ]] && ./support/utils/nix-build-travis-fold.sh --fallback -I fractalide=. release.nix -A rs-tests
+ - bash -c '[[ $(uname) == Linux ]] && ./support/utils/nix-build-travis-fold.sh --fallback -I fractalide=. release.nix -A rs-tests'
  - ./support/utils/nix-build-travis-fold.sh --fallback -I fractalide=. release.nix -A fractalide
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: nix
 
 script:
  - sudo env NIX_PATH=$NIX_PATH $(which nix-shell) ./support/utils/setup-hydra.fractalide.com.sh
- - ./support/utils/nix-build-travis-fold.sh --fallback -I fractalide=. -A fractalide release.nix
+ - [[ $(uname) == Linux ]] && ./support/utils/nix-build-travis-fold.sh --fallback -I fractalide=. release.nix -A rs-tests
+ - ./support/utils/nix-build-travis-fold.sh --fallback -I fractalide=. release.nix -A fractalide
 
 matrix:
   include:

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -13,7 +13,18 @@ pkgs {
   overlays = [
     (import (builtins.toPath "${rustOverlay}/rust-overlay.nix"))
     (self: super: rec {
-      rust = let channel = self.rustChannelOf { date = "2018-04-01"; channel = "nightly"; }; in {
+      rust = let
+        fromManifestFixed = manifest: sha256: { stdenv, fetchurl, patchelf }:
+          self.lib.rustLib.fromManifestFile
+            (fetchurl { url = manifest; sha256 = sha256; })
+            { inherit stdenv fetchurl patchelf; };
+        rustChannelOfFixed = manifest_args: sha256: fromManifestFixed
+          (self.lib.rustLib.manifest_v2_url manifest_args) sha256
+          { inherit (self) stdenv fetchurl patchelf; };
+        channel = rustChannelOfFixed
+          { date = "2018-04-01"; channel = "nightly"; }
+          "186lzxrff9pyakgcf7gv604abl7dcjmy69ilk762anmwya3lgjmj";
+      in {
         rustc = channel.rust;
         inherit (channel) cargo;
       };

--- a/release.nix
+++ b/release.nix
@@ -7,4 +7,6 @@ with import <fractalide> {};
     fractapkgs = import ./pkgs { pkgs = nixpkgs; };
   in
     fractapkgs.fractalide;
+} // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+  rs-tests = import ./tests;
 }


### PR DESCRIPTION
The Mozilla Rust overlay is impure.

Solution: Make the manifest download fixed-output.

Add rust tests to release.nix and .travis.yml.

The Linux test in .travis.yml is a bit ugly, but will go away once
travisOrder is done over on racket2nix and can be brought over.