### PR TITLE
Problem: misspelled 'channels'

### DIFF
--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -25,8 +25,7 @@ function build() {
   local nixpkgs_paths=()
 
   for path in \
-    $HOME/.nix-defexpr/channel/nixpkgs \
-    /home/travis/.nix-defexpr/channels/nixpkgs \
+    $HOME/.nix-defexpr/channels/nixpkgs \
     /nix/var/nix/profiles/per-user/root/channels/nixpkgs \
   ; do
     [[ -e $path ]] &&


### PR DESCRIPTION
So that's why that explicit /home/travis was necessary.

Solution: Spell 'channels' correctly, remove /home/travis line.

This makes nix-build-travis-fold.sh work locally.