### PR TITLE
Problem: Too much fvm boilerplate

### DIFF
--- a/modules/rkt/rkt-fbp/hyperflow.rkt
+++ b/modules/rkt/rkt-fbp/hyperflow.rkt
@@ -7,12 +7,7 @@
 (require (prefix-in graph: fractalide/modules/rkt/rkt-fbp/graph))
 
 (module+ main
-  (define sched (make-scheduler #f))
-  (setup-fvm sched)
-  (sched (msg-mesg "sched" "acc" (make-scheduler #f)))
-  (sched (msg-mesg "halt" "in" #f))
-  (define path (fbp-agents-string->symbol "hyperflow/run"))
-  (define a-graph (graph:make-graph (graph:node "main" path)))
-  (sched (msg-mesg "fvm" "in" (cons 'add a-graph)))
-  (sched (msg-mesg "fvm" "in" (cons 'stop #t)))
-  (sched (msg-stop)))
+  (call-with-new-fvm-and-scheduler (lambda (fvm-sched sched)
+    (define path (fbp-agents-string->symbol "hyperflow/run"))
+    (define a-graph (graph:make-graph (graph:node "main" path)))
+    (fvm-sched (msg-mesg "fvm" "in" (cons 'add a-graph))))))


### PR DESCRIPTION
Solution: Copy call-with-new-fvm-and-scheduler from cardano-wallet.

Apply in fvm and hyperflow.

Copied from:
fractalide/cardano-wallet f4d1b0013bc981d867a751a9c533b8c0c30cc2d8

cardano-wallet has it in a wrapper.rkt, but put it right into fvm.rkt,
just like with how fvm/setup was imported (back in
55a0994a946645dc25dc55c9ca94574c8ffc07fd ).