### PR TITLE
 Problem: paging-jsend-get: Test loads paging-jsend-get 

### DIFF
--- a/nodes/rkt/paging-jsend-get.rkt
+++ b/nodes/rkt/paging-jsend-get.rkt
@@ -107,7 +107,7 @@
    "Trivial HTTP request returning 1 item only"
    (define sched (make-scheduler #f))
    (define state-port (make-port 30 #f #f #f))
-   (for ([msg (list (msg-add-agent "jsend" 'fractalide/nodes/rkt/paging-jsend-get/main)
+   (for ([msg (list (msg-add-agent "jsend" 'fractalide/nodes/rkt/paging-jsend-get)
                     (msg-add-agent "mock" 'fractalide/nodes/rkt/paging-jsend-get/test/mock)
                     (msg-connect "jsend" "http" "mock" "in")
                     (msg-connect "mock" "out" "jsend" "http")

--- a/nodes/rkt/paging-jsend-get/main.rkt
+++ b/nodes/rkt/paging-jsend-get/main.rkt
@@ -107,8 +107,8 @@
    "Trivial HTTP request returning 1 item only"
    (define sched (make-scheduler #f))
    (define state-port (make-port 30 #f #f #f))
-   (for ([msg (list (msg-add-agent "jsend" 'paging-jsend-get)
-                    (msg-add-agent "mock" 'paging-jsend-get/test/mock)
+   (for ([msg (list (msg-add-agent "jsend" 'fractalide/nodes/rkt/paging-jsend-get/main)
+                    (msg-add-agent "mock" 'fractalide/nodes/rkt/paging-jsend-get/test/mock)
                     (msg-connect "jsend" "http" "mock" "in")
                     (msg-connect "mock" "out" "jsend" "http")
                     (msg-connect "jsend" "out" "mock" "jsend")

--- a/nodes/rkt/paging-jsend-get/test/mock.rkt
+++ b/nodes/rkt/paging-jsend-get/test/mock.rkt
@@ -4,7 +4,7 @@
 
 (require fractalide/modules/rkt/rkt-fbp/agent)
 
-(require paging-jsend-get)
+(require fractalide/nodes/rkt/paging-jsend-get/main)
 
 (define-agent
   #:input '("in" "jsend")

--- a/nodes/rkt/paging-jsend-get/test/mock.rkt
+++ b/nodes/rkt/paging-jsend-get/test/mock.rkt
@@ -4,7 +4,7 @@
 
 (require fractalide/modules/rkt/rkt-fbp/agent)
 
-(require fractalide/nodes/rkt/paging-jsend-get/main)
+(require fractalide/nodes/rkt/paging-jsend-get)
 
 (define-agent
   #:input '("in" "jsend")


### PR DESCRIPTION
This collection no longer exists.

Solution: Load `fractalide/nodes/rkt/paging-jsend-get/main` instead.

`raco test .` in the root of fractalide successfully runs the test.

This should be in `release.nix` and more modules should have tests in
their `test` submodule. But first we should make running node tests
more convenient, which I guess goes under #238. Once we have that,
quicktest is just one way to formulate a test case.

The way `paging-jsend-get` tests itself can be viewed as a first
prototype and an example of what kind of boilerplate we would
like to put into a convenience interface.

Instead of being an external module, `test/mock` could be a submodule --
if we think spreading files around doesn't look nice and if the mock
is small enough. It's possible that we could make a mock generator
macro that creates a mock for your needs as a submodule, to keep the
mock definition concise.