### PR TITLE
Problem: cardano-wallet: No right-hand side

### DIFF
--- a/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
@@ -24,8 +24,18 @@
   (mesg "menu-about" "in" #t)
   (mesg "menu-about" "option" "About")
 
-  (node "welcome" ${cardano-wallet.menu})
-  (edge "welcome" "out" _ "frame" "in" _))
+  (node "app" ${gui.horizontal-panel})
+  (edge "app" "out" _ "frame" "in" _)
+
+  (node "sidebar" ${cardano-wallet.menu})
+  (edge "sidebar" "out" _ "app" "place" 10)
+
+  (node "stack" ${gui.place-holder})
+  (edge "stack" "out" _ "app" "place" 20)
+
+  (node "welcome" ${cardano-wallet.welcome})
+  (edge "welcome" "out" _ "stack" "place" 30)
+  (mesg "welcome" "in" '(display . #t)))
 
 (module+ main
   (require syntax/location)

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/welcome.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/welcome.rkt
@@ -5,6 +5,7 @@
 (define-graph
   (node "vp" ${gui.vertical-panel})
   (edge-out "vp" "out" "out")
+  (edge-in "in" "vp" "in")
 
   (node "headline" ${gui.message})
   (edge "headline" "out" _ "vp" "place" 1)


### PR DESCRIPTION
Solution: Use place-holder to be able to flip widgets.

Put welcome screen as initial right-hand side.