### PR TITLE
Problem: Too much console debug spam

### DIFF
--- a/modules/rkt/rkt-fbp/agents/gui/frame/frame.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/frame/frame.rkt
@@ -27,5 +27,9 @@
      [(cons 'dynamic-remove graph)
       (send (output "fvm") msg)]
      [(cons 'close #t) (send (output "halt") #t) (send (output "fvm") (cons 'stop #t))]
+     [(cons (or 'motion 'leave 'enter 'left-down 'left-up 'subwindow-focus
+                'move 'superwindow-show 'size 'focus 'radio-box 'key 'list-box
+                'text-field 'check-box 'slider)
+            _) (void)]
      [else (display "msg: ") (displayln msg)])
    (send (output "acc") fr)))


### PR DESCRIPTION
Solution: Silence debug output from `frame` for the unhandled events we are aware of.