### PR TITLE
Problem: No wallet settings screen

### DIFF
--- a/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
@@ -63,6 +63,14 @@
   (mesg "transaction-2" "from" '(init . ((label . "23456789"))))
   (mesg "transaction-2" "to" '(init . ((label . "87654321"))))
 
+  (node "wsettings" ${cardano-wallet.wsettings})
+  (edge "wsettings" "out" _ "stack" "place" 30)
+  (mesg "wsettings" "name" "My first wallet")
+
+  (node "display-wallet-name" ${displayer})
+  (mesg "display-wallet-name" "option" "wallet name: ")
+  (edge "wsettings" "name" _ "display-wallet-name" "in" _)
+
   (node "card-display-in" ${plumbing.option-transform})
   (mesg "card-display-in" "option" (match-lambda [(cons dest _) (list* dest 'display #t)]))
 
@@ -71,7 +79,8 @@
 
   (edge "sidebar" "choice" _ "card-display-in" "in" _)
   (edge "card-display-out" "out" "new" "welcome" "in" _)
-  (edge "card-display-out" "out" "summary" "summary" "in" _))
+  (edge "card-display-out" "out" "summary" "summary" "in" _)
+  (edge "card-display-out" "out" "wsettings" "wsettings" "in" _))
 
 (module+ main
   (require syntax/location)

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/wsettings.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/wsettings.rkt
@@ -1,0 +1,30 @@
+#lang racket
+
+(require fractalide/modules/rkt/rkt-fbp/graph)
+
+(define-graph
+  (node "vp" ${gui.vertical-panel})
+  (edge-out "vp" "out" "out")
+  (edge-in "in" "vp" "in")
+
+  (node "headline" ${gui.message})
+  (edge "headline" "out" _ "vp" "place" 10)
+  (mesg "headline" "in" '(init . ((label . "Wallet settings"))))
+
+  (node "name-label" ${gui.message})
+  (edge "name-label" "out" _ "vp" "place" 20)
+  (mesg "name-label" "in" '(init . ((label . "Name"))))
+
+  (node "name" ${gui.text-field})
+  (edge "name" "out" _ "vp" "place" 30)
+  (mesg "name" "in" '(init . ((label . ""))))
+
+  (node "name-in" ${plumbing.option-transform})
+  (mesg "name-in" "option" (lambda (x) (cons 'set-value x)))
+  (edge "name-in" "out" _ "name" "in" _)
+  (edge-in "name" "name-in" "in")
+
+  (node "name-out" ${plumbing.option-transform})
+  (mesg "name-out" "option" cdr)
+  (edge "name" "out" 'text-field-enter "name-out" "in" _)
+  (edge-out "name-out" "out" "name"))


### PR DESCRIPTION
Solution: Implement a card with the Name text field.

Partly solves fractalide/cardano-wallet#22 .

Still missing:
 - Transaction assurance level
 - Password
 - Delete wallet

 - Feedback from wallet name field to wallet name dropdown in sidebar
 - Wallet name dropdown in sidebar