### PR TITLE
Problem: wsettings: No assurance level setting

### DIFF
--- a/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
@@ -67,6 +67,11 @@
   (edge "wsettings" "out" _ "stack" "place" 30)
   (mesg "wsettings" "name" "My first wallet")
 
+  (node "display-assurance-level" ${displayer})
+  (mesg "display-assurance-level" "option" "display-assurance-level: ")
+  (edge "wsettings" "assurance-level" _ "display-assurance-level" "in" _)
+  (mesg "wsettings" "assurance-level" "Medium")
+
   (node "display-wallet-name" ${displayer})
   (mesg "display-wallet-name" "option" "wallet name: ")
   (edge "wsettings" "name" _ "display-wallet-name" "in" _)

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/wsettings.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/wsettings.rkt
@@ -27,4 +27,22 @@
   (node "name-out" ${plumbing.option-transform})
   (mesg "name-out" "option" cdr)
   (edge "name" "out" 'text-field-enter "name-out" "in" _)
-  (edge-out "name-out" "out" "name"))
+  (edge-out "name-out" "out" "name")
+
+  (node "assurance-level-label" ${gui.message})
+  (edge "assurance-level-label" "out" _ "vp" "place" 40)
+  (mesg "assurance-level-label" "in" '(init . ((label . "Transaction assurance security level"))))
+
+  (node "assurance-level" ${gui.choice})
+  (edge "assurance-level" "out" _ "vp" "place" 50)
+  (mesg "assurance-level" "in" '(init . ((choices . ("Low" "Medium" "High")))))
+
+  (node "assurance-level-in" ${plumbing.option-transform})
+  (mesg "assurance-level-in" "option" (lambda (choice) (cons 'set-string-selection choice)))
+  (edge "assurance-level-in" "out" _  "assurance-level" "in" _)
+  (edge-in "assurance-level" "assurance-level-in" "in")
+
+  (node "assurance-level-out" ${plumbing.option-transform})
+  (mesg "assurance-level-out" "option" (match-lambda [(cons 'choice choice) choice]))
+  (edge "assurance-level" "out" 'choice "assurance-level-out" "in" _)
+  (edge-out "assurance-level-out" "out" "assurance-level"))


### PR DESCRIPTION
Solution: Add choice widget and edges.

Partly solves fractalide/cardano-wallet#22 .

Items done:
 - `[✓]` Transaction assurance level
 - `[ ]` Password
 - `[ ]` Delete wallet

 - `[ ]` Feedback from wallet name field to wallet name dropdown in sidebar
 - `[ ]` Wallet name dropdown in sidebar