### PR TITLE
Problem: mux and demux are named exactly wrong

### DIFF
--- a/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
@@ -79,7 +79,7 @@
   (node "card-display-in" ${plumbing.option-transform})
   (mesg "card-display-in" "option" (match-lambda [(cons dest _) (list* dest 'display #t)]))
 
-  (node "card-display-out" ${plumbing.mux})
+  (node "card-display-out" ${plumbing.demux})
   (edge "card-display-in" "out" _ "card-display-out" "in" _)
 
   (edge "sidebar" "choice" _ "card-display-in" "in" _)

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/menu.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/menu.rkt
@@ -16,7 +16,7 @@
   (edge "headline" "out" _ "vp" "place" 0)
   (mesg "headline" "in" `(init . ((label . ,fractalide-logo))))
 
-  (node "button-pushes" ${plumbing.demux})
+  (node "button-pushes" ${plumbing.mux})
   (edge-out "button-pushes" "out" "choice")
 
   (node "summary" ${gui.button})

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/password.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/password.rkt
@@ -72,7 +72,7 @@
   (edge "confirm-button" "out" 'button "set-password" "in" _)
   (edge-out "set-password" "out" "password")
 
-  (node "passwords-match-out" ${plumbing.mux})
+  (node "passwords-match-out" ${plumbing.demux})
   (edge "passwords-match" "out" _ "passwords-match-out" "in" _)
   (edge "passwords-match-out" "out" "valid" "confirm-button" "in" _)
   (edge "passwords-match-out" "out" "password" "set-password" "password" _))

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/transaction.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/transaction.rkt
@@ -56,7 +56,7 @@
                                         (lambda (_) (list* "no-details" 'display #t))))
   (edge "details-button" "out" 'button "details-toggle" "in" _)
 
-  (node "details-choice" ${plumbing.mux})
+  (node "details-choice" ${plumbing.demux})
   (edge "details-toggle" "out" _ "details-choice" "in" _)
 
   (node "maybe-details" ${gui.place-holder})

--- a/modules/rkt/rkt-fbp/agents/plumbing/demux.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/demux.rkt
@@ -3,12 +3,11 @@
 (require fractalide/modules/rkt/rkt-fbp/agent)
 
 (define-agent
-  #:input-array '("in")
-  #:output '("out")
+  #:input '("in")
+  #:output-array '("out")
   (fun
-   (for ([(selection port) (input-array "in")])
-        (define msg (try-recv port))
-        (when msg (send (output "out") (cons selection msg))))))
+   (define msg (recv (input "in")))
+   (send (hash-ref (output-array "out") (car msg)) (cdr msg))))
 
 (module+ test
   (require rackunit)
@@ -19,7 +18,7 @@
   (require fractalide/modules/rkt/rkt-fbp/scheduler)
 
   (test-case
-   "Sending message Y to port X yields message (X . Y)"
+   "Sending message (X . Y) yields message Y on port X"
    (define sched (make-scheduler #f))
    (define tap (make-port 30 #f #f #f))
 
@@ -27,13 +26,11 @@
    (define msg "hello")
 
    (sched (msg-add-agent "agent-under-test" (quote-module-path ".."))
-          (msg-raw-connect "agent-under-test" "out" tap)
-
           (msg-add-agent "identity" 'plumbing/identity)
-          (msg-connect-to-array "identity" "out" "agent-under-test" "in" selection))
 
-   (sched (msg-mesg "identity" "in" msg))
-   (check-equal? (port-recv tap)
-                 (cons selection msg))
+          (msg-connect-array-to "agent-under-test" "out" selection "identity" "in")
+          (msg-raw-connect "identity" "out" tap))
+
+   (sched (msg-mesg "agent-under-test" "in" (cons selection msg)))
+   (check-equal? (port-recv tap) msg)
    (sched (msg-stop))))
-


### PR DESCRIPTION
    multiplexing [ . . . ] is a method by which multiple analog or
    digital signals are combined into one signal over a shared medium

       -- https://en.wikipedia.org/wiki/Multiplexing

In our case, muxing needs to be when you take an input array, label
the messages and output them on a single output.

Solution: Rename them and all references to them.