### PR TITLE
 Problem: Password confirm/cancel does not clear password fields

### DIFF
--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/password.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/password.rkt
@@ -31,6 +31,19 @@
   (mesg "confirm-password" "in" '(init . ((label . "Confirm new password")
                                           (style . (single password)))))
 
+  (node "initialize-password" ${plumbing.mux})
+
+  (node "initialize-password-trans" ${plumbing.transform-in-msgs})
+  (mesg "initialize-password-trans" "option" (match-lambda [(cons _ password)
+                                                            (list (list* "new-password" 'set-value password)
+                                                                  (list* "confirm-password" 'set-value password))]))
+  (edge "initialize-password" "out" _ "initialize-password-trans" "in" _)
+
+  (node "initialize-password-out" ${plumbing.demux})
+  (edge "initialize-password-trans" "out" _ "initialize-password-out" "in" _)
+  (edge "initialize-password-out" "out" "new-password" "new-password" "in" _)
+  (edge "initialize-password-out" "out" "confirm-password" "confirm-password" "in" _)
+
   (node "passwords-match" ${plumbing.transform-ins-msgs})
   (mesg "passwords-match" "option"
         (match-lambda [(hash-table ("new" (cons 'text-field new))
@@ -57,19 +70,37 @@
   (mesg "confirm-button" "in" '(init . ((label . "Change")
                                         (enabled . #f))))
 
+  (node "confirm-button-trans" ${plumbing.transform-in-msgs})
+  (mesg "confirm-button-trans" "option"
+        (match-lambda [(cons 'button #t)
+                       (list (list* "set-password" 'button #t)
+                             (cons "finish" #t))]))
+  (edge "confirm-button" "out" 'button "confirm-button-trans" "in" _)
+
+  (node "confirm-button-out" ${plumbing.demux})
+  (edge "confirm-button-trans" "out" _ "confirm-button-out" "in" _)
+
   (node "cancel-button" ${gui.button})
   (edge "cancel-button" "out" _ "buttons" "place" 20)
   (mesg "cancel-button" "in" '(init . ((label . "Cancel"))))
 
-  (node "cancel" ${plumbing.option-transform})
-  (mesg "cancel" "option"
-        (match-lambda [(cons 'button #t) (cons 'display #t)]))
-  (edge "cancel-button" "out" 'button "cancel" "in" _)
-  (edge "cancel" "out" _ "change-button" "in" _)
-  ; should probably also reset password fields
+  (node "finish" ${plumbing.mux})
+  (edge "cancel-button" "out" 'button "finish" "in" "cancel")
+  (edge "confirm-button-out" "out" "finish" "finish" "in" "confirm")
+
+  (node "finish-trans" ${plumbing.transform-in-msgs})
+  (mesg "finish-trans" "option"
+        (lambda (_) (list (list* "change-button" 'display #t)
+                          (cons "initialize-password" ""))))
+  (edge "finish" "out" _ "finish-trans" "in" _)
+
+  (node "finish-out" ${plumbing.demux})
+  (edge "finish-trans" "out" _ "finish-out" "in" _)
+  (edge "finish-out" "out" "change-button" "change-button" "in" _)
+  (edge "finish-out" "out" "initialize-password" "initialize-password" "in" "finish")
 
   (node "set-password" ${cardano-wallet.set-password})
-  (edge "confirm-button" "out" 'button "set-password" "in" _)
+  (edge "confirm-button-out" "out" "set-password" "set-password" "in" _)
   (edge-out "set-password" "out" "password")
 
   (node "passwords-match-out" ${plumbing.demux})

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/set-password.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/set-password.rkt
@@ -8,7 +8,6 @@
   (fun
    (define maybe-passwd (try-recv (input "password")))
    (define maybe-acc (try-recv (input "acc")))
-   (eprintf "passwd ~a acc ~a~n" maybe-passwd maybe-acc)
    (define password (or maybe-passwd maybe-acc))
    (define button-pushed? (try-recv (input "in")))
    (when (and button-pushed? (and password (> (string-length password) 0)))

--- a/modules/rkt/rkt-fbp/agents/plumbing/transform-in-msgs.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/transform-in-msgs.rkt
@@ -1,0 +1,93 @@
+#lang racket
+
+(require fractalide/modules/rkt/rkt-fbp/agent)
+
+(define-agent
+  #:input '("in")
+  #:output '("out")
+  (fun
+   (for ([msg ((recv (input "option")) (recv (input "in")))])
+     (send (output "out") msg))))
+
+(module+ test
+  (require rackunit)
+  (require syntax/location)
+
+  (require fractalide/modules/rkt/rkt-fbp/def)
+  (require fractalide/modules/rkt/rkt-fbp/port)
+  (require fractalide/modules/rkt/rkt-fbp/scheduler)
+
+  (test-case
+   "Identity function"
+   (define sched (make-scheduler #f))
+   (define tap (make-port 30 #f #f #f))
+
+   (define msg "hello")
+
+   (sched (msg-add-agent "agent-under-test" (quote-module-path ".."))
+          (msg-raw-connect "agent-under-test" "out" tap))
+
+   (sched (msg-mesg "agent-under-test" "option" list))
+
+   (sched (msg-mesg "agent-under-test" "in" msg))
+   (check-equal? (port-recv tap) msg)
+
+   (sched (msg-mesg "agent-under-test" "in" msg))
+   (check-equal? (port-recv tap) msg)
+
+   (sched (msg-stop)))
+
+  (test-case
+   "Reverse function"
+   (define sched (make-scheduler #f))
+   (define tap (make-port 30 #f #f #f))
+
+   (define msg '(1 2 3))
+
+   (sched (msg-add-agent "agent-under-test" (quote-module-path ".."))
+          (msg-raw-connect "agent-under-test" "out" tap))
+
+   (sched (msg-mesg "agent-under-test" "option" (compose list reverse)))
+
+   (sched (msg-mesg "agent-under-test" "in" msg))
+   (check-equal? (port-recv tap) (reverse msg))
+
+   (sched (msg-mesg "agent-under-test" "in" (reverse msg)))
+   (check-equal? (port-recv tap) msg)
+
+   (sched (msg-stop)))
+
+  (test-case
+   "No messages"
+   (define sched (make-scheduler #f))
+   (define tap (make-port 30 #f #f #f))
+
+   (define msg '(1 2 3))
+
+   (sched (msg-add-agent "agent-under-test" (quote-module-path ".."))
+          (msg-raw-connect "agent-under-test" "out" tap))
+
+   (sched (msg-mesg "agent-under-test" "option" (lambda (_) (list))))
+
+   (sched (msg-mesg "agent-under-test" "in" msg))
+   (check-false (port-try-recv tap))
+
+   (sched (msg-stop)))
+
+  (test-case
+   "Two messages"
+   (define sched (make-scheduler #f))
+   (define tap (make-port 30 #f #f #f))
+
+   (define msg '(1 2))
+
+   (sched (msg-add-agent "agent-under-test" (quote-module-path ".."))
+          (msg-raw-connect "agent-under-test" "out" tap))
+
+   (sched (msg-mesg "agent-under-test" "option" identity))
+
+   (sched (msg-mesg "agent-under-test" "in" msg))
+   (check-equal? (port-recv tap) (first msg))
+   (check-equal? (port-recv tap) (second msg))
+
+   (sched (msg-stop))))


### PR DESCRIPTION
Solution: Add this action to the buttons.

Create shared "finish" action for both buttons to activate, make it
both change state and clear fields.

Remove debug eprintf from `${cardano-wallet.set-password}`.