### PR TITLE
 Problem: Some common patterns are too verbose

### DIFF
--- a/modules/rkt/rkt-fbp/agents/plumbing/demux.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/demux.rkt
@@ -35,4 +35,25 @@
 
    (sched (msg-mesg "agent-under-test" "in" (cons selection msg)))
    (check-equal? (port-recv tap) msg)
+   (sched (msg-stop)))
+
+  (test-case
+   "Transform"
+   (define sched (make-scheduler #f))
+   (define tap (make-port 30 #f #f #f))
+
+   (define selection "the-selection")
+   (define msg '(1 2 3 4))
+
+   (sched (msg-add-agent "agent-under-test" (quote-module-path ".."))
+          (msg-add-agent "identity" 'plumbing/identity)
+
+          (msg-connect-array-to "agent-under-test" "out" selection "identity" "in")
+          (msg-raw-connect "identity" "out" tap))
+
+   (sched (msg-mesg "agent-under-test" "option"
+                    (match-lambda [(cons sel data)
+                                   (list (cons sel (reverse data)))]))
+          (msg-mesg "agent-under-test" "in" (cons selection msg)))
+   (check-equal? (port-recv tap) (reverse msg))
    (sched (msg-stop))))

--- a/modules/rkt/rkt-fbp/agents/plumbing/demux.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/demux.rkt
@@ -6,8 +6,10 @@
   #:input '("in")
   #:output-array '("out")
   (fun
-   (define msg (recv (input "in")))
-   (send (hash-ref (output-array "out") (car msg)) (cdr msg))))
+   (define in-msg (recv (input "in")))
+   (define f (or (try-recv (input "option")) list))
+   (for ([msg (f in-msg)])
+        (send (hash-ref (output-array "out") (car msg)) (cdr msg)))))
 
 (module+ test
   (require rackunit)

--- a/modules/rkt/rkt-fbp/agents/plumbing/mux-demux.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/mux-demux.rkt
@@ -1,0 +1,89 @@
+#lang racket
+
+(require fractalide/modules/rkt/rkt-fbp/agent)
+
+(define-agent
+  #:input-array '("in")
+  #:output-array '("out")
+  (fun
+   (define f (or (try-recv (input "option")) list))
+   (for ([(selection port) (input-array "in")])
+        (define in-msg (try-recv port))
+        (when in-msg
+              (for ([sel-msg (f (cons selection in-msg))])
+                   (match-define (cons sel msg) sel-msg)
+                   (send (hash-ref (output-array "out") sel) msg))))))
+
+(module+ test
+  (require rackunit)
+  (require syntax/location)
+
+  (require fractalide/modules/rkt/rkt-fbp/def)
+  (require fractalide/modules/rkt/rkt-fbp/port)
+  (require fractalide/modules/rkt/rkt-fbp/scheduler)
+
+  (test-case
+   "Sending message Y to port X yields message Y on port X"
+   (define sched (make-scheduler #f))
+   (define tap (make-port 30 #f #f #f))
+
+   (define selection "the-selection")
+   (define msg "hello")
+
+   (sched (msg-add-agent "agent-under-test" (quote-module-path ".."))
+
+          (msg-add-agent "in" 'plumbing/identity)
+          (msg-add-agent "out" 'plumbing/identity)
+          (msg-connect-to-array "in" "out" "agent-under-test" "in" selection)
+          (msg-connect-array-to "agent-under-test" "out" selection "out" "in")
+          (msg-raw-connect "out" "out" tap))
+
+   (sched (msg-mesg "in" "in" msg))
+   (check-equal? (port-recv tap) msg)
+   (sched (msg-stop)))
+
+  (test-case
+   "Transform msg"
+   (define sched (make-scheduler #f))
+   (define tap (make-port 30 #f #f #f))
+
+   (define selection "the-selection")
+   (define msg '(1 2 3 4))
+
+   (sched (msg-add-agent "agent-under-test" (quote-module-path ".."))
+
+          (msg-add-agent "in" 'plumbing/identity)
+          (msg-add-agent "out" 'plumbing/identity)
+          (msg-connect-to-array "in" "out" "agent-under-test" "in" selection)
+          (msg-connect-array-to "agent-under-test" "out" selection "out" "in")
+          (msg-raw-connect "out" "out" tap))
+
+   (sched (msg-mesg "agent-under-test" "option"
+                    (match-lambda [(cons sel msg)
+                                   (list (cons sel (reverse msg)))]))
+          (msg-mesg "in" "in" msg))
+   (check-equal? (port-recv tap) (reverse msg))
+   (sched (msg-stop)))
+
+  (test-case
+   "Reroute"
+   (define sched (make-scheduler #f))
+   (define tap (make-port 30 #f #f #f))
+
+   (define in-selection "the-selection")
+   (define out-selection "other-selection")
+   (define msg '(1 2 3 4))
+
+   (sched (msg-add-agent "agent-under-test" (quote-module-path ".."))
+
+          (msg-add-agent "in" 'plumbing/identity)
+          (msg-add-agent "out" 'plumbing/identity)
+          (msg-connect-to-array "in" "out" "agent-under-test" "in" in-selection)
+          (msg-connect-array-to "agent-under-test" "out" out-selection "out" "in")
+          (msg-raw-connect "out" "out" tap))
+
+   (sched (msg-mesg "agent-under-test" "option"
+                    (match-lambda [(cons (== in-selection) msg)
+                                   (list (cons out-selection msg))]))
+          (msg-mesg "in" "in" msg))
+   (check-equal? (port-recv tap) msg)))

--- a/modules/rkt/rkt-fbp/agents/plumbing/mux.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/mux.rkt
@@ -38,5 +38,26 @@
    (sched (msg-mesg "identity" "in" msg))
    (check-equal? (port-recv tap)
                  (cons selection msg))
-   (sched (msg-stop))))
+   (sched (msg-stop)))
 
+  (test-case
+   "Transform"
+   (define sched (make-scheduler #f))
+   (define tap (make-port 30 #f #f #f))
+
+   (define selection "the-selection")
+   (define msg '(1 2 3 4))
+
+   (sched (msg-add-agent "agent-under-test" (quote-module-path ".."))
+          (msg-raw-connect "agent-under-test" "out" tap)
+
+          (msg-add-agent "identity" 'plumbing/identity)
+          (msg-connect-to-array "identity" "out" "agent-under-test" "in" selection))
+
+   (sched (msg-mesg "agent-under-test" "option"
+                    (match-lambda [(cons sel msg)
+                                   (list (cons sel (reverse msg)))]))
+          (msg-mesg "identity" "in" msg))
+   (check-equal? (port-recv tap)
+                 (cons selection (reverse msg)))
+   (sched (msg-stop))))

--- a/modules/rkt/rkt-fbp/agents/plumbing/mux.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/mux.rkt
@@ -6,9 +6,12 @@
   #:input-array '("in")
   #:output '("out")
   (fun
+   (define f (or (try-recv (input "option")) list))
    (for ([(selection port) (input-array "in")])
-        (define msg (try-recv port))
-        (when msg (send (output "out") (cons selection msg))))))
+        (define in-msg (try-recv port))
+        (when in-msg
+              (for ([msg (f (cons selection in-msg))])
+                   (send (output "out") msg))))))
 
 (module+ test
   (require rackunit)


### PR DESCRIPTION
 - mux is often followed by in-transform-msgs.
 - demux is often preceded by in-transform-msgs.
 - There is often a chain mux-transform-demux.

Solution: Merge transform functionality into mux and demux for the
half-patterns, add a combined mux-demux agent for the full pattern.

Make use of the improved plumbing to make cardano-wallet.password
less verbose.