### PR TITLE
 Problem: cardano-wallet: No wallets dropdown

### DIFF
--- a/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
@@ -65,7 +65,7 @@
 
   (node "wsettings" ${cardano-wallet.wsettings})
   (edge "wsettings" "out" _ "stack" "place" 30)
-  (mesg "wsettings" "name" "My first wallet")
+  (edge "sidebar" "data" "wallet-name" "wsettings" "name" _)
 
   (node "display-assurance-level" ${displayer})
   (mesg "display-assurance-level" "option" "display-assurance-level: ")

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/menu.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/menu.rkt
@@ -16,6 +16,12 @@
   (edge "headline" "out" _ "vp" "place" 0)
   (mesg "headline" "in" `(init . ((label . ,fractalide-logo))))
 
+  (node "wallets-choice" ${cardano-wallet.wallets-choice})
+  (edge "wallets-choice" "out" _ "vp" "place" 5)
+  (mesg "wallets-choice" "in" '(init . ()))
+  (mesg "wallets-choice" "init" '(#hash((name . "my wallet"))
+                                  #hash((name . "my other wallet is also a wallet"))))
+
   (node "button-pushes" ${plumbing.mux})
   (edge-out "button-pushes" "out" "choice")
 

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/menu.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/menu.rkt
@@ -22,6 +22,12 @@
   (mesg "wallets-choice" "init" '(#hash((name . "my wallet"))
                                   #hash((name . "my other wallet is also a wallet"))))
 
+  (node "wallet-data" ${plumbing.demux})
+  (mesg "wallet-data" "option"
+	(lambda (data) (list (cons "wallet-name" (hash-ref data 'name)))))
+  (edge "wallets-choice" "choice" _ "wallet-data" "in" _)
+  (edge-out "wallet-data" "out" "data")
+
   (node "button-pushes" ${plumbing.mux})
   (edge-out "button-pushes" "out" "choice")
 

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-choice.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-choice.rkt
@@ -1,0 +1,41 @@
+#lang racket
+
+(require fractalide/modules/rkt/rkt-fbp/graph)
+
+(define-graph
+  (node "choice" ${gui.choice})
+  (edge-out "choice" "out" "out")
+
+  (node "choice-fan-in" ${plumbing.mux})
+  (mesg "choice-fan-in" "option"
+	(match-lambda [(cons _ data)
+		       (list data)]))
+  (edge "choice-fan-in" "out" _ "choice" "in" _)
+
+  (node "choice-in" ${plumbing.identity})
+  (edge-in "in" "choice-in" "in")
+  (edge "choice-in" "out" _ "choice-fan-in" "in" "in")
+
+  (node "choice-cmd" ${plumbing.mux})
+  (edge "choice-cmd" "out" _ "choice-fan-in" "in" "cmd")
+
+  (node "get-selection-cmd" ${plumbing.transform-in-msgs})
+  (mesg "get-selection-cmd" "option"
+        (match-lambda [(cons 'choice _)
+                       (list (list* 'get-selection 'get-selection))]))
+  (edge "choice" "out" 'choice "get-selection-cmd" "in" _)
+  (edge "get-selection-cmd" "out" _ "choice-fan-in" "in" "get-selection-cmd")
+
+  (node "select" ${plumbing.transform-in-msgs})
+  (mesg "select" "option"
+	(match-lambda [(cons 'get-selection selection)
+		       (list selection)]))
+  (edge "choice" "out" 'get-selection "select" "in" _)
+
+  (node "model" ${cardano-wallet.wallets-model})
+  (edge-in "add" "model" "add")
+  (edge-in "delete" "model" "delete")
+  (edge-in "init" "model" "in")
+  (edge "select" "out" _ "model" "select" _)
+  (edge "model" "select" _ "choice-cmd" "in" 'set-selection)
+  (edge "model" "choices" _ "choice-cmd" "in" 'set-choices))

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-choice.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-choice.rkt
@@ -38,4 +38,5 @@
   (edge-in "init" "model" "in")
   (edge "select" "out" _ "model" "select" _)
   (edge "model" "select" _ "choice-cmd" "in" 'set-selection)
-  (edge "model" "choices" _ "choice-cmd" "in" 'set-choices))
+  (edge "model" "choices" _ "choice-cmd" "in" 'set-choices)
+  (edge-out "model" "out" "choice"))

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-model.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-model.rkt
@@ -10,7 +10,7 @@
 
 (define-agent
   #:input ports
-  #:output '("out" "select")
+  #:output '("out" "choices" "select")
   (fun
    (define acc (or (try-recv (input "acc")) (list)))
    (define action (for/or ([port ports])
@@ -19,15 +19,19 @@
    (for ([port-msg (match action
                     [(cons "in" (list))
                      (list (cons "acc" (list))
+                           (cons "choices" (list))
                            (cons "select" 0)
                            (cons "out" (make-hash)))]
                     [(cons "in" (list-rest head rest))
-                     (list (cons "acc" (list* head rest))
+                     (define new-acc (list* head rest))
+                     (list (cons "acc" new-acc)
+                           (cons "choices" (map (lambda (h) (hash-ref h 'name)) new-acc))
                            (cons "select" 0)
                            (cons "out" head))]
                     [(cons "add" wallet-data)
-                     (list (cons "acc"
-                                 (append acc (list wallet-data)))
+                     (define new-acc (append acc (list wallet-data)))
+                     (list (cons "acc" new-acc)
+                           (cons "choices" (map (lambda (h) (hash-ref h 'name)) new-acc))
                            (cons "select" (length acc))
                            (cons "out" wallet-data))]
                     [(cons "delete" selection)
@@ -35,6 +39,7 @@
                                                 selection))
                      (define new-acc (list-remove-index acc selection))
                      (list (cons "acc" new-acc)
+                           (cons "choices" (map (lambda (h) (hash-ref h 'name)) new-acc))
                            (cons "select" new-selection)
                            (cons "out" (list-ref new-acc new-selection)))]
                     [(cons "select" selection)
@@ -54,82 +59,89 @@
   (test-case
    "In"
    (define sched (make-scheduler #f))
-   (define taps (for/hash ([port '("select" "out")]) (values port (make-port 30 #f #f #f))))
+   (define taps (for/hash ([port '("choices" "select" "out")]) (values port (make-port 30 #f #f #f))))
 
    (sched (msg-add-agent "agent-under-test" (quote-module-path "..")))
 
    (for ([(port tap) (in-hash taps)])
         (sched (msg-raw-connect "agent-under-test" port tap)))
 
-   (define wallets (list #hash(("name" . "asdf"))
-                         #hash(("name" . "qwer"))))
+   (define choices '("asdf" "qwer"))
+   (define wallets (map (lambda (choice) (make-hash (list (cons 'name choice)))) choices))
 
    (sched (msg-mesg "agent-under-test" "in" wallets))
    (check-equal? (port-recv (hash-ref taps "select")) 0)
    (check-equal? (port-recv (hash-ref taps "out")) (car wallets))
+   (check-equal? (port-recv (hash-ref taps "choices")) choices)
    (sched (msg-stop)))
 
   (test-case
    "Select"
    (define sched (make-scheduler #f))
-   (define taps (for/hash ([port '("select" "out")]) (values port (make-port 30 #f #f #f))))
+   (define taps (for/hash ([port '("choices" "select" "out")]) (values port (make-port 30 #f #f #f))))
 
    (sched (msg-add-agent "agent-under-test" (quote-module-path "..")))
 
    (for ([(port tap) (in-hash taps)])
         (sched (msg-raw-connect "agent-under-test" port tap)))
 
-   (define wallets (list #hash(("name" . "asdf"))
-                         #hash(("name" . "qwer"))))
+   (define wallets (list #hash((name . "asdf"))
+                         #hash((name . "qwer"))))
 
    (sched (msg-mesg "agent-under-test" "in" wallets))
    (port-recv (hash-ref taps "select"))
    (port-recv (hash-ref taps "out"))
+   (port-recv (hash-ref taps "choices"))
 
    (sched (msg-mesg "agent-under-test" "select" 1))
    (check-equal? (port-recv (hash-ref taps "out")) (second wallets))
+   (check-equal? (port-try-recv (hash-ref taps "choices")) #f)
    (sched (msg-stop)))
 
   (test-case
    "Add"
    (define sched (make-scheduler #f))
-   (define taps (for/hash ([port '("select" "out")]) (values port (make-port 30 #f #f #f))))
+   (define taps (for/hash ([port '("choices" "select" "out")]) (values port (make-port 30 #f #f #f))))
 
    (sched (msg-add-agent "agent-under-test" (quote-module-path "..")))
 
    (for ([(port tap) (in-hash taps)])
         (sched (msg-raw-connect "agent-under-test" port tap)))
 
-   (define wallets (list #hash(("name" . "asdf"))
-                         #hash(("name" . "qwer"))))
+   (define choices '("asdf" "qwer"))
+   (define wallets (map (lambda (choice) (make-hash (list (cons 'name choice)))) choices))
 
    (sched (msg-mesg "agent-under-test" "add" (first wallets)))
    (check-equal? (port-recv (hash-ref taps "select")) 0)
    (check-equal? (port-recv (hash-ref taps "out")) (first wallets))
+   (check-equal? (port-recv (hash-ref taps "choices")) (list (first choices)))
 
    (sched (msg-mesg "agent-under-test" "add" (second wallets)))
    (check-equal? (port-recv (hash-ref taps "select")) 1)
    (check-equal? (port-recv (hash-ref taps "out")) (second wallets))
+   (check-equal? (port-recv (hash-ref taps "choices")) choices)
    (sched (msg-stop)))
 
   (test-case
    "Delete"
    (define sched (make-scheduler #f))
-   (define taps (for/hash ([port '("select" "out")]) (values port (make-port 30 #f #f #f))))
+   (define taps (for/hash ([port '("choices" "select" "out")]) (values port (make-port 30 #f #f #f))))
 
    (sched (msg-add-agent "agent-under-test" (quote-module-path "..")))
 
    (for ([(port tap) (in-hash taps)])
         (sched (msg-raw-connect "agent-under-test" port tap)))
 
-   (define wallets (list #hash(("name" . "asdf"))
-                         #hash(("name" . "qwer"))))
+   (define choices '("asdf" "qwer"))
+   (define wallets (map (lambda (choice) (make-hash (list (cons 'name choice)))) choices))
 
    (sched (msg-mesg "agent-under-test" "in" wallets))
    (port-recv (hash-ref taps "select"))
    (port-recv (hash-ref taps "out"))
+   (port-recv (hash-ref taps "choices"))
 
    (sched (msg-mesg "agent-under-test" "delete" 0))
    (check-equal? (port-recv (hash-ref taps "select")) 0)
    (check-equal? (port-recv (hash-ref taps "out")) (second wallets))
+   (check-equal? (port-recv (hash-ref taps "choices")) (list (second choices)))
    (sched (msg-stop))))

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-model.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-model.rkt
@@ -1,0 +1,65 @@
+#lang racket
+
+(require fractalide/modules/rkt/rkt-fbp/agent)
+
+(define (list-remove-index lst idx)
+  (define-values (heads tail) (split-at lst idx))
+  (append heads (cdr tail)))
+
+(define-agent
+  #:input '("in" "add" "select" "delete")
+  #:output '("out")
+  (fun
+   (define acc (or (try-recv (input "acc")) (make-hash)))
+   (define action (for/or ([port '("in" "add" "delete")])
+                          (define val (try-recv (input port)))
+                          (if val (cons port val) #f)))
+   (for ([port-msg (match action
+                    [(cons "in" (list))
+                     (list (cons "acc" (list))
+                           (cons "selection" 0)
+                           (cons "out" (make-hash)))]
+                    [(cons "in" (list-rest head rest))
+                     (list (cons "acc" (list* head rest))
+                           (cons "selection" 0)
+                           (cons "out" head))]
+                    [(cons "add" wallet-data)
+                     (list (cons "acc"
+                                 (append acc (list wallet-data)))
+                           (cons "selection" (length acc))
+                           (cons "out" wallet-data))]
+                    [(cons "delete" selection)
+                     (define new-selection (min (max 0 (- (length acc) 2))
+                                                selection))
+                     (define new-acc (list-remove-index acc selection))
+                     (list (cons "acc" new-acc)
+                           (cons "selection" new-selection)
+                           (cons "out" (list-ref new-acc new-selection)))])])
+        (match-define (cons port msg) port-msg)
+        (send (output port) msg))))
+
+(module+ test
+  (require rackunit)
+  (require syntax/location)
+
+  (require fractalide/modules/rkt/rkt-fbp/def)
+  (require fractalide/modules/rkt/rkt-fbp/port)
+  (require fractalide/modules/rkt/rkt-fbp/scheduler)
+
+  (test-case
+   "Initializing gives us head wallet"
+   (define sched (make-scheduler #f))
+   (define taps (for/hash ([port '("selection" "out")]) (values port (make-port 30 #f #f #f))))
+
+   (sched (msg-add-agent "agent-under-test" (quote-module-path "..")))
+
+   (for ([(port tap) (in-hash taps)])
+        (sched (msg-raw-connect "agent-under-test" port tap)))
+
+   (define wallets (list #hash(("name" . "asdf"))
+                         #hash(("name" . "qwer"))))
+
+   (sched (msg-mesg "agent-under-test" "in" wallets))
+   (check-equal? (port-recv (hash-ref taps "selection")) 0)
+   (check-equal? (port-recv (hash-ref taps "out")) (car wallets))
+   (sched (msg-stop))))

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-model.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-model.rkt
@@ -6,35 +6,40 @@
   (define-values (heads tail) (split-at lst idx))
   (append heads (cdr tail)))
 
+(define ports '("in" "add" "select" "delete"))
+
 (define-agent
-  #:input '("in" "add" "select" "delete")
-  #:output '("out")
+  #:input ports
+  #:output '("out" "select")
   (fun
    (define acc (or (try-recv (input "acc")) (make-hash)))
-   (define action (for/or ([port '("in" "add" "delete")])
+   (define action (for/or ([port ports])
                           (define val (try-recv (input port)))
                           (if val (cons port val) #f)))
    (for ([port-msg (match action
                     [(cons "in" (list))
                      (list (cons "acc" (list))
-                           (cons "selection" 0)
+                           (cons "select" 0)
                            (cons "out" (make-hash)))]
                     [(cons "in" (list-rest head rest))
                      (list (cons "acc" (list* head rest))
-                           (cons "selection" 0)
+                           (cons "select" 0)
                            (cons "out" head))]
                     [(cons "add" wallet-data)
                      (list (cons "acc"
                                  (append acc (list wallet-data)))
-                           (cons "selection" (length acc))
+                           (cons "select" (length acc))
                            (cons "out" wallet-data))]
                     [(cons "delete" selection)
                      (define new-selection (min (max 0 (- (length acc) 2))
                                                 selection))
                      (define new-acc (list-remove-index acc selection))
                      (list (cons "acc" new-acc)
-                           (cons "selection" new-selection)
-                           (cons "out" (list-ref new-acc new-selection)))])])
+                           (cons "select" new-selection)
+                           (cons "out" (list-ref new-acc new-selection)))]
+                    [(cons "select" selection)
+                     (list (cons "acc" acc)
+                           (cons "out" (list-ref acc selection)))])])
         (match-define (cons port msg) port-msg)
         (send (output port) msg))))
 
@@ -49,7 +54,7 @@
   (test-case
    "Initializing gives us head wallet"
    (define sched (make-scheduler #f))
-   (define taps (for/hash ([port '("selection" "out")]) (values port (make-port 30 #f #f #f))))
+   (define taps (for/hash ([port '("select" "out")]) (values port (make-port 30 #f #f #f))))
 
    (sched (msg-add-agent "agent-under-test" (quote-module-path "..")))
 
@@ -60,6 +65,27 @@
                          #hash(("name" . "qwer"))))
 
    (sched (msg-mesg "agent-under-test" "in" wallets))
-   (check-equal? (port-recv (hash-ref taps "selection")) 0)
+   (check-equal? (port-recv (hash-ref taps "select")) 0)
    (check-equal? (port-recv (hash-ref taps "out")) (car wallets))
+   (sched (msg-stop)))
+
+  (test-case
+   "Initialize then select"
+   (define sched (make-scheduler #f))
+   (define taps (for/hash ([port '("select" "out")]) (values port (make-port 30 #f #f #f))))
+
+   (sched (msg-add-agent "agent-under-test" (quote-module-path "..")))
+
+   (for ([(port tap) (in-hash taps)])
+        (sched (msg-raw-connect "agent-under-test" port tap)))
+
+   (define wallets (list #hash(("name" . "asdf"))
+                         #hash(("name" . "qwer"))))
+
+   (sched (msg-mesg "agent-under-test" "in" wallets))
+   (port-recv (hash-ref taps "select"))
+   (port-recv (hash-ref taps "out"))
+
+   (sched (msg-mesg "agent-under-test" "select" 1))
+   (check-equal? (port-recv (hash-ref taps "out")) (second wallets))
    (sched (msg-stop))))

--- a/modules/rkt/rkt-fbp/agents/gui/choice.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/choice.rkt
@@ -53,8 +53,12 @@
   (set! managed (list-control-manage widget msg output output-array))
   (if managed
       (void)
-      (send-action output output-array msg)))
-
+      (match msg
+             [(cons 'get-selection act)
+              (send-action output output-array (cons act (class:send widget get-selection)))]
+             [(cons 'set-selection n)
+              (class:send widget set-selection n)]
+             [else (send-action output output-array msg)])))
 
 (define-agent
   #:input '("in") ; in port

--- a/modules/rkt/rkt-fbp/agents/gui/choice.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/choice.rkt
@@ -54,6 +54,9 @@
   (if managed
       (void)
       (match msg
+	     [(cons 'set-choices choices)
+	      (class:send widget clear)
+	      (for ([choice choices]) (class:send widget append choice))]
              [(cons 'get-selection act)
               (send-action output output-array (cons act (class:send widget get-selection)))]
              [(cons 'set-selection n)


### PR DESCRIPTION
We want a widget in the sidebar for choosing between different
wallets. It should list the names of the wallets, and choosing one
should update the wallet settings and other widgets with the
corresponding information.

Also, changing wallet settings etc should update the internal state of
the widget (or, the wallets, if you prefer).

Solution: Implement the model to hold the wallets, the pairing with
the visual widget, and connect the edges to the right places.

Missing: Summary page label is not updated by the dropdown.

Partly solves fractalide/cardano-wallet#22 .

Items done:
 - `[✓]` Transaction assurance level
 - `[✓]` Password
 - `[ ]` Delete wallet

 - `[ ]` Feedback from wallet name field to wallet name dropdown in sidebar
 - `[✓]` Wallet name dropdown in sidebar