### PR TITLE
Problem: Not detecting hung tests

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -62,12 +62,12 @@ pkgs {
 
         # parallel cannot quite handle full inline bash, and destroys quoting, so we can't use bash -c
         racoTest = builtins.toFile "raco-test.sh" ''
-          racket -l- raco test "$@" |&
+          timeout 20 time -f '%e s' racket -l- raco test "$@" |&
             grep -v -e "warning: tool .* registered twice" -e "@[(]test-responsible"
           exit ''${PIPESTATUS[0]}
         '';
       in self.runCommand "rkt-tests" {
-        buildInputs = [ fractalide-rkt-tests.env self.parallel ];
+        buildInputs = [ fractalide-rkt-tests.env self.coreutils self.parallel self.time ];
         inherit racoTest;
       } ''
         # If we do raco test <directory> the discovery process will try to mkdir $HOME.


### PR DESCRIPTION
Our tests are only detecting faulty signals, not whether you'll have
to wait forever for the signal.

Solution: Run each test suite with a timeout.

Also measure the times, so we can see how far we are from the limit.

Currently all of the tests run in under 10 s each on my machine. Files
with no tests discovered take 5--6 s. So my chosen timeout of 20 s has
a 3x margin on the actual test portion.