### PR TITLE
 Problem: wsettings: No way to delete a wallet

### DIFF
--- a/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
@@ -84,7 +84,12 @@
   (edge "sidebar" "choice" _ "card-display-in" "in" _)
   (edge "card-display-out" "out" "new" "welcome" "in" _)
   (edge "card-display-out" "out" "summary" "summary" "in" _)
-  (edge "card-display-out" "out" "wsettings" "wsettings" "in" _))
+  (edge "card-display-out" "out" "wsettings" "wsettings" "in" _)
+
+  (mesg "sidebar" "in" '(init . ()))
+  (mesg "sidebar" "init" '(#hash((name . "my wallet"))
+                           #hash((name . "my other wallet is also a wallet")))))
+
 
 (module+ main
   (require syntax/location)

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
@@ -73,6 +73,7 @@
   (mesg "wsettings" "assurance-level" "Medium")
 
   (edge "wsettings" "name" _ "sidebar" "data" "wallet-name")
+  (edge "wsettings" "delete" _ "sidebar" "data" "delete")
 
   (node "card-display-in" ${plumbing.option-transform})
   (mesg "card-display-in" "option" (match-lambda [(cons dest _) (list* dest 'display #t)]))

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/delete.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/delete.rkt
@@ -1,0 +1,86 @@
+#lang racket
+
+(require fractalide/modules/rkt/rkt-fbp/graph)
+
+(define-graph
+  (node "ph" ${gui.place-holder})
+  (edge-out "ph" "out" "out")
+  (edge-in "in" "ph" "in")
+
+  (node "button" ${gui.button})
+  (edge "button" "out" _ "ph" "place" 10)
+  (mesg "button" "in" '(init . ((label . "Delete wallet ..."))))
+  (mesg "button" "in" '(display . #t))
+
+  (node "button-out" ${plumbing.option-transform})
+  (mesg "button-out" "option"
+        (match-lambda [(cons 'button #t) '(display . #t)]))
+  (edge "button" "out" 'button "button-out" "in" _)
+
+  (node "controls" ${gui.vertical-panel})
+  (edge "controls" "out" _ "ph" "place" 20)
+  (edge "button-out" "out" _ "controls" "in" _)
+
+  (node "wallet-name-in" ${plumbing.identity})
+  (edge-in "wallet-name" "wallet-name-in" "in")
+
+  (node "wallet-name" ${plumbing.mux-demux})
+  (mesg "wallet-name" "option"
+        (match-lambda [(cons _ new-name)
+                       (list (list* "text-field" 'set-value "")
+                             (cons "match" new-name))]))
+  (edge "wallet-name-in" "out" _ "wallet-name" "in" "init")
+
+  (node "confirm-wallet-name" ${gui.text-field})
+  (edge "confirm-wallet-name" "out" _ "controls" "place" 20)
+  (mesg "confirm-wallet-name" "in" '(init . ((label . "Confirm name of wallet to delete"))))
+  (edge "wallet-name" "out" "text-field" "confirm-wallet-name" "in" _)
+
+  (node "names-match" ${plumbing.transform-ins-msgs})
+  (mesg "names-match" "option"
+        (match-lambda [(hash-table ("actual" actual)
+                                   ("confirm" (cons 'text-field confirm)))
+
+                       (define disable (list (cons 'set-enabled #f)))
+                       (define enable (list (cons 'set-enabled #t)))
+
+                       (cond
+                         [(= 0 (string-length actual)) disable]
+                         [(equal? actual confirm) enable]
+                         [else disable])]))
+
+  (edge "wallet-name" "out" "match" "names-match" "in" "actual")
+  (edge "confirm-wallet-name" "out" 'text-field "names-match" "in" "confirm")
+
+  (node "buttons" ${gui.horizontal-panel})
+  (edge "buttons" "out" _ "controls" "place" 30)
+
+  (node "confirm-button" ${gui.button})
+  (edge "confirm-button" "out" _ "buttons" "place" 10)
+  (mesg "confirm-button" "in" '(init . ((label . "Delete")
+                                        (enabled . #f))))
+  (edge "names-match" "out" _ "confirm-button" "in" _)
+
+  (node "confirm-button-out" ${plumbing.demux})
+  (mesg "confirm-button-out" "option"
+        (match-lambda [(cons 'button #t)
+                       (list (cons "delete" #t)
+                             (cons "finish" #t))]))
+  (edge "confirm-button" "out" 'button "confirm-button-out" "in" _)
+
+  (node "cancel-button" ${gui.button})
+  (edge "cancel-button" "out" _ "buttons" "place" 20)
+  (mesg "cancel-button" "in" '(init . ((label . "Cancel"))))
+
+  (node "finish" ${plumbing.mux-demux})
+  (mesg "finish" "option"
+        (lambda (_) (list (list* "button" 'display #t)
+                          (cons "wallet-name" ""))))
+  (edge "cancel-button" "out" 'button "finish" "in" "cancel")
+  (edge "confirm-button-out" "out" "finish" "finish" "in" "confirm")
+  (edge "finish" "out" "button" "button" "in" _)
+  (edge "finish" "out" "wallet-name" "wallet-name" "in" "finish")
+
+  (node "delete-out" ${plumbing.identity})
+  (edge "confirm-button-out" "out" "delete" "delete-out" "in" _)
+  (edge-out "delete-out" "out" "delete"))

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/sidebar.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/sidebar.rkt
@@ -25,8 +25,11 @@
   (node "wallet-data-in" ${plumbing.mux-demux})
   (mesg "wallet-data-in" "option"
         (match-lambda [(cons "wallet-name" new-name)
-                       (list (cons "edit" `#hash((name . ,new-name))))]))
+                       (list (cons "edit" `#hash((name . ,new-name))))]
+                      [(cons "delete" _)
+                       (list (cons "delete" #t))]))
   (edge "wallet-data-in" "out" "edit" "wallets-choice" "edit" _)
+  (edge "wallet-data-in" "out" "delete" "wallets-choice" "delete" _)
   (edge-in "data" "wallet-data-in" "in")
 
   (node "wallet-data-out" ${plumbing.demux})

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/sidebar.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/sidebar.rkt
@@ -18,9 +18,9 @@
 
   (node "wallets-choice" ${cardano-wallet.wallets-choice})
   (edge "wallets-choice" "out" _ "vp" "place" 5)
-  (mesg "wallets-choice" "in" '(init . ()))
-  (mesg "wallets-choice" "init" '(#hash((name . "my wallet"))
-                                  #hash((name . "my other wallet is also a wallet"))))
+
+  (edge-in "in" "wallets-choice" "in")
+  (edge-in "init" "wallets-choice" "init")
 
   (node "wallet-data-in" ${plumbing.mux-demux})
   (mesg "wallet-data-in" "option"
@@ -30,6 +30,7 @@
                        (list (cons "delete" #t))]))
   (edge "wallet-data-in" "out" "edit" "wallets-choice" "edit" _)
   (edge "wallet-data-in" "out" "delete" "wallets-choice" "delete" _)
+  (edge "wallet-data-in" "out" "init" "wallets-choice" "init" _)
   (edge-in "data" "wallet-data-in" "in")
 
   (node "wallet-data-out" ${plumbing.demux})

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-model.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-model.rkt
@@ -51,6 +51,15 @@
                            (cons "choices" (map (lambda (h) (hash-ref h 'name)) new-state))
                            (cons "select" selection)
                            (cons "out" new-wallet-data))]
+                    [(cons "delete" #t)
+                     (define new-selection (min (max 0 (- (length state) 2))
+                                                selection))
+                     (define new-state (list-remove-index state selection))
+                     (list (cons "acc" `#hash((state . ,new-state)
+                                              (selection . ,new-selection)))
+                           (cons "choices" (map (lambda (h) (hash-ref h 'name)) new-state))
+                           (cons "select" new-selection)
+                           (cons "out" (list-ref new-state new-selection)))]
                     [(cons "delete" delete-selection)
                      (define new-selection (min (max 0 (- (length state) 2))
                                                 selection))
@@ -165,6 +174,22 @@
     (port-recv (hash-ref taps "choices"))
 
     (sched (msg-mesg "agent-under-test" "delete" 0))
+    (check-equal? (port-recv (hash-ref taps "select")) 0)
+    (check-equal? (port-recv (hash-ref taps "out")) (second wallets))
+    (check-equal? (port-recv (hash-ref taps "choices")) (list (second choices))))))
+
+  (test-case
+   "Delete current"
+   (run-sched-test (lambda (sched taps)
+    (define choices '("asdf" "qwer"))
+    (define wallets (map (lambda (choice) (make-hash (list (cons 'name choice)))) choices))
+
+    (sched (msg-mesg "agent-under-test" "in" wallets))
+    (port-recv (hash-ref taps "select"))
+    (port-recv (hash-ref taps "out"))
+    (port-recv (hash-ref taps "choices"))
+
+    (sched (msg-mesg "agent-under-test" "delete" #t))
     (check-equal? (port-recv (hash-ref taps "select")) 0)
     (check-equal? (port-recv (hash-ref taps "out")) (second wallets))
     (check-equal? (port-recv (hash-ref taps "choices")) (list (second choices)))))))

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/wsettings.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/wsettings.rkt
@@ -19,9 +19,12 @@
   (edge "name" "out" _ "vp" "place" 30)
   (mesg "name" "in" '(init . ((label . ""))))
 
-  (node "name-in" ${plumbing.option-transform})
-  (mesg "name-in" "option" (lambda (x) (cons 'set-value x)))
-  (edge "name-in" "out" _ "name" "in" _)
+  (node "name-in" ${plumbing.demux})
+  (mesg "name-in" "option"
+        (lambda (new-name) (list (list* "name" 'set-value new-name)
+                                 (list* "delete" new-name))))
+  (edge "name-in" "out" "name" "name" "in" _)
+  (edge "name-in" "out" "delete" "delete" "wallet-name" _)
   (edge-in "name" "name-in" "in")
 
   (node "name-out" ${plumbing.option-transform})
@@ -62,5 +65,4 @@
   (node "delete" ${cardano-wallet.delete})
   (edge "delete" "out" _ "vp" "place" 80)
   (mesg "delete" "in" '(display . #t))
-  (edge-out "delete" "delete" "delete")
-  (mesg "delete" "wallet-name" "my wallet"))
+  (edge-out "delete" "delete" "delete"))

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/wsettings.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/wsettings.rkt
@@ -57,4 +57,10 @@
 
   (node "display-password" ${displayer})
   (mesg "display-password" "option" "set password: ")
-  (edge "password" "password" _ "display-password" "in" _))
+  (edge "password" "password" _ "display-password" "in" _)
+
+  (node "delete" ${cardano-wallet.delete})
+  (edge "delete" "out" _ "vp" "place" 80)
+  (mesg "delete" "in" '(display . #t))
+  (edge-out "delete" "delete" "delete")
+  (mesg "delete" "wallet-name" "my wallet"))


### PR DESCRIPTION

Solution: Implement and connect delete widget.

 - Implement current-choice deletion in wallets-model.
 - Implement buttons and state.
 - Connect things up.
 - Refactor sidebar to allow later init, so things time right.

Closes fractalide/cardano-wallet#22 .

Items done:
 - `[✓]` Transaction assurance level
 - `[✓]` Password
 - `[✓]` Delete wallet
 - `[✓]` Feedback from wallet name field to wallet name dropdown in sidebar
 - `[✓]` Wallet name dropdown in sidebar