### PR TITLE
Problem: pkgs.fractalide: The name of the package varies

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -32,10 +32,12 @@ pkgs {
         inherit (channel) cargo;
       };
       inherit racket2nix;
-      inherit (racket2nix) buildRacket;
+      inherit (racket2nix) buildRacketPackage;
       rustPlatform = super.recurseIntoAttrs (super.makeRustPlatform rust);
-      fractalide = self.buildRacket {
-        package = builtins.filterSource (path: type:
+      fractalide = self.buildRacketPackage (builtins.path {
+        name = "fractalide";
+        path = ./..;
+        filter = (path: type:
           let basePath = baseNameOf path; in
           (type != "symlink" || null == builtins.match "result.*" basePath) &&
           (null == builtins.match ".*[.]nix" basePath) &&
@@ -43,8 +45,8 @@ pkgs {
           (null == builtins.match "[.][#].*" basePath) &&
           (null == builtins.match "[#].*[#]" basePath) &&
           (null == builtins.match ".*~" basePath)
-        ) ./..;
-      };
+        );
+      });
 
       # fractalide/racket2nix#78 workaround
 

--- a/pkgs/racket2nix/default.nix
+++ b/pkgs/racket2nix/default.nix
@@ -3,8 +3,8 @@ let
   pinnedPkgs = bootPkgs.fetchFromGitHub {
     owner = "fractalide";
     repo = "racket2nix";
-    rev = "b36a72442b487e6d8f7c8f58f84a1d1f7b13fcb8";
-    sha256 = "146cahd80ib2nrx7402q1p3m0p3gb6qi5lkbnr92bpfxadwy3g3c";
+    rev = "138fdfde9362f3a4cfff7a57b689afa77da72cbf";
+    sha256 = "0dpcc945mwvqbs8609gn5cbgj6q9hsqxrgcbdxbj7jy0dgyrpi33";
   };
 in
 import pinnedPkgs


### PR DESCRIPTION
That's because racket2nix (and racket) relies on the path basename to
determine the name of a package.

This causes issues when we want to depend on fractalide, and the
package ends up named source or git-export.

Solution: Use builtins.path to explicitly name the path.

Closes #138