### PR TITLE
Problem: raco test doesn't work

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -58,7 +58,7 @@ pkgs {
           sha1 = "8921c26c498e920aca398df7afb0ab486636430f";
         })];
         # Remove compiler-lib from its own dependencies.
-        racketBuildInputs = builtins.filter (input: input.name != "compiler-lib") oldAttrs.racketBuildInputs;
+        racketBuildInputs = builtins.filter (input: input.pname or "" != "compiler-lib") oldAttrs.racketBuildInputs;
       })).overrideAttrs (oldAttrs: { name = "fractalide-rkt-tests"; });
 
       rkt-tests = let

--- a/pkgs/racket2nix/default.nix
+++ b/pkgs/racket2nix/default.nix
@@ -3,8 +3,8 @@ let
   pinnedPkgs = bootPkgs.fetchFromGitHub {
     owner = "fractalide";
     repo = "racket2nix";
-    rev = "b1f25241bf4b5aefd518ed99dd283bde05350117";
-    sha256 = "19cc0qiqmbbmbdqrk438pn200nvnj3phdhj4sy5av3b6kv785i33";
+    rev = "8eedab8676476f730c2de2905c3c1377c7bad82c";
+    sha256 = "09c8w5c79559lpvp4ghf9dbnywdddykv4irm8b9ykzv01qbwr4gw";
   };
 in
 import pinnedPkgs

--- a/pkgs/racket2nix/default.nix
+++ b/pkgs/racket2nix/default.nix
@@ -3,8 +3,8 @@ let
   pinnedPkgs = bootPkgs.fetchFromGitHub {
     owner = "fractalide";
     repo = "racket2nix";
-    rev = "8eedab8676476f730c2de2905c3c1377c7bad82c";
-    sha256 = "09c8w5c79559lpvp4ghf9dbnywdddykv4irm8b9ykzv01qbwr4gw";
+    rev = "b1f25241bf4b5aefd518ed99dd283bde05350117";
+    sha256 = "19cc0qiqmbbmbdqrk438pn200nvnj3phdhj4sy5av3b6kv785i33";
   };
 in
 import pinnedPkgs


### PR DESCRIPTION
```
/nix/store/8b2ycliakg6zsisbqcihfs9wlzgpdgsg-racket-minimal-6.12/bin/racket: Unrecognized command: test
```

The problem is that although `compiler-lib` is added as a source to
fractalide-rkt-tests, it is not filtered out as a dependency, so it's
never installed.

The filter acts on `name`, but racket2nix now names the derivation
`<racket-derivation>-<pname>`, so the filter looks for `compiler-lib`
and lets `racket-6.12-compiler-lib` through.

Solution: Filter `fractalide-rkt-tests` dependencies on `pname`.

 - Bump to fractalide/racket2nix#190 which makes `pname` available.

Closes fractalide/racket2nix#189