### PR TITLE
Problem: Running cardano-wallet.rkt requires 'racket'

### DIFF
--- a/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
@@ -1,3 +1,4 @@
+#!/usr/bin/env racket
 #lang racket
 
 (require fractalide/modules/rkt/rkt-fbp/graph)


### PR DESCRIPTION
When installed, it has the 'cardano-wallet' launcher, but not during
development. Typing 'racket' each time gets tedious.

Solution: Add hashbang to 'cardano-wallet.rkt', and mode 755.