### PR TITLE
 Problem: define-agent: Requires the 'fun' workaround

### DIFF
--- a/modules/rkt/rkt-fbp/agent.rkt
+++ b/modules/rkt/rkt-fbp/agent.rkt
@@ -9,7 +9,7 @@
          agent-connect agent-connect-to-array agent-connect-array-to
          agent-disconnect agent-disconnect-to-array agent-disconnect-array-to
          agent-no-input?
-         make-agent define-agent fun)
+         make-agent define-agent)
 
 (require racket/list
          racket/match
@@ -220,5 +220,3 @@
        (define agt (,#'opt-agent ,#'input ,#'input-array ,#'output ,#'output-array
                               (lambda (input output input-array output-array)
                                       . ,#'(body ...))))))]))
-
-(define-syntax-rule (fun body ...) (begin body ...))

--- a/modules/rkt/rkt-fbp/agents/IO/file/open.rkt
+++ b/modules/rkt/rkt-fbp/agents/IO/file/open.rkt
@@ -6,6 +6,5 @@
 (define-agent
   #:input '("in") ; in array port
   #:output '("out") ; out port
-  (fun
     (define path (recv (input "in")))
-    (send (output "out") (file->string path))))
+    (send (output "out") (file->string path)))

--- a/modules/rkt/rkt-fbp/agents/IO/file/write.rkt
+++ b/modules/rkt/rkt-fbp/agents/IO/file/write.rkt
@@ -9,11 +9,10 @@
 (define-agent
   #:input '("in") ; in array port
   #:output '("out") ; out port
-  (fun
     (define data (recv (input "in")))
     (define option (recv (input "option")))
     (display-to-file data
                    (write-path option)
                    #:exists (write-exists option)
                    #:mode (write-mode option))
-    (send (output "out") (file->string (write-path option)))))
+    (send (output "out") (file->string (write-path option))))

--- a/modules/rkt/rkt-fbp/agents/adder.rkt
+++ b/modules/rkt/rkt-fbp/agents/adder.rkt
@@ -5,8 +5,7 @@
 (define-agent
   #:input-array '("in") ; in array port
   #:output '("out") ; out port
-  (fun
    (define sum (for/fold ([sum 0])
                          ([(k v) (input-array "in")])
                  (+ sum (recv v))))
-   (send (output "out") sum)))
+   (send (output "out") sum))

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/set-password.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/set-password.rkt
@@ -5,14 +5,13 @@
 (define-agent
   #:input '("in" "password")
   #:output '("out")
-  (fun
    (define maybe-passwd (try-recv (input "password")))
    (define maybe-acc (try-recv (input "acc")))
    (define password (or maybe-passwd maybe-acc))
    (define button-pushed? (try-recv (input "in")))
    (when (and button-pushed? (and password (> (string-length password) 0)))
          (send (output "out") password))
-   (send (output "acc") password)))
+   (send (output "acc") password))
 
 (module+ test
   (require rackunit)

--- a/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-model.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet/wallets-model.rkt
@@ -16,7 +16,6 @@
 (define-agent
   #:input in-ports
   #:output out-ports
-  (fun
    (define acc (or (try-recv (input "acc")) #hash((selection . 0) (state . ()))))
    (match-define (hash-table ('selection selection) ('state state)) acc)
    (define action (for/or ([port in-ports])
@@ -73,7 +72,7 @@
                      (list (cons "acc" (hash-set acc 'selection new-selection))
                            (cons "out" (list-ref state new-selection)))])])
         (match-define (cons port msg) port-msg)
-        (send (output port) msg))))
+        (send (output port) msg)))
 
 (module+ test
   (require rackunit)

--- a/modules/rkt/rkt-fbp/agents/clone.rkt
+++ b/modules/rkt/rkt-fbp/agents/clone.rkt
@@ -5,7 +5,6 @@
 (define-agent
   #:input '("in") ; in port
   #:output-array '("out") ; out array port
-  (fun
    (let* ([msg (recv (input "in"))])
      (for ([(k v) (output-array "out")])
-       (send v msg)))))
+       (send v msg))))

--- a/modules/rkt/rkt-fbp/agents/delayer.rkt
+++ b/modules/rkt/rkt-fbp/agents/delayer.rkt
@@ -5,7 +5,6 @@
 (define-agent
   #:input '("in") ; in port
   #:output '("out") ; out port
-  (fun
    (define msg (recv (input "in")))
    (sleep 2)
-   (send (output "out") msg)))
+   (send (output "out") msg))

--- a/modules/rkt/rkt-fbp/agents/displayer.rkt
+++ b/modules/rkt/rkt-fbp/agents/displayer.rkt
@@ -5,11 +5,10 @@
 (define-agent
   #:input '("in") ; in port
   #:output '("out") ; out port
-  (fun
    (define msg (recv (input "in")))
    (define option (try-recv (input "option")))
    (if option
        (display option)
        (void))
    (displayln msg)
-   (send (output "out") msg)))
+   (send (output "out") msg))

--- a/modules/rkt/rkt-fbp/agents/dummy.rkt
+++ b/modules/rkt/rkt-fbp/agents/dummy.rkt
@@ -3,5 +3,4 @@
 (require fractalide/modules/rkt/rkt-fbp/agent)
 
 (define-agent
-  (fun
-   (displayln "I'm dummy, I do nothing!")))
+   (displayln "I'm dummy, I do nothing!"))

--- a/modules/rkt/rkt-fbp/agents/fvm/fvm.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/fvm.rkt
@@ -12,7 +12,6 @@
 (define-agent
   #:input '("in" "flat") ; in port
   #:output '("sched" "flat" "out" "halt") ; out port
-  (fun
    (let* ([try-acc (try-recv (input "acc"))]
           [acc (if try-acc try-acc (g:graph '() '() '() '() '()))]
           [msg (recv (input "in"))])
@@ -41,7 +40,7 @@
           (send (output "halt") #t)
           (send (output "sched") (msg-stop))
           acc]))
-     (send (output "acc") new-acc))))
+     (send (output "acc") new-acc)))
 
 (define (send-sched-remove rem actual input output)
   ; Flat the graph

--- a/modules/rkt/rkt-fbp/agents/fvm/get-graph.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/get-graph.rkt
@@ -8,7 +8,6 @@
 (define-agent
   #:input '("in")
   #:output '("out")
-  (fun
    (let* ([agt (recv (input "in"))]
           [name (g-agent-name agt)]
           [type (g-agent-type agt)])
@@ -33,4 +32,4 @@
            [new-mesg
             (for/list ([mesg (graph-mesg g)])
               (struct-copy g-mesg mesg [in (string-append name "-" (g-mesg-in mesg))]))])
-       (send (output "out") (graph new-agent new-edge new-virtual-in new-virtual-out new-mesg))))))
+       (send (output "out") (graph new-agent new-edge new-virtual-in new-virtual-out new-mesg)))))

--- a/modules/rkt/rkt-fbp/agents/fvm/get-path.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/get-path.rkt
@@ -19,9 +19,8 @@
 (define-agent
   #:input '("in")
   #:output '("out")
-  (fun
    (let* ([agt (recv (input "in"))])
      (define new-type (maybe-nix-string->module-path-or-passthrough (g-agent-type agt)))
      (define new-agent (struct-copy g-agent agt
                                     [type new-type]))
-     (send (output "out") new-agent))))
+     (send (output "out") new-agent)))

--- a/modules/rkt/rkt-fbp/agents/fvm/load-graph.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/load-graph.rkt
@@ -45,7 +45,6 @@
 (define-agent
   #:input '("in" "ask-path" "ask-graph")
   #:output '("out" "ask-path" "ask-graph")
-  (fun
    (let* ([msg (recv (input "in"))])
      (define flat (flat-graph msg input output))
-     (send (output "out") flat))))
+     (send (output "out") flat)))

--- a/modules/rkt/rkt-fbp/agents/fvm/scheduler.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/scheduler.rkt
@@ -9,9 +9,7 @@
 (define-agent
   #:input '("in")
   #:output '("out")
-  (fun
    (let* ([sched (recv (input "acc"))]
           [msg (recv (input "in"))])
      (sched msg)
-     (send (output "acc") sched))
-   ))
+     (send (output "acc") sched)))

--- a/modules/rkt/rkt-fbp/agents/gui/button.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/button.rkt
@@ -56,8 +56,7 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg (recv (input "in")))
     (set! acc (manage acc msg input output output-array generate process-msg))
-    (send (output "acc") acc)))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/gui/canvas.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/canvas.rkt
@@ -55,7 +55,6 @@
   #:input-array '("place")
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg-in (try-recv (input "in")))
     ; Init the first time
@@ -91,7 +90,7 @@
                         [else (send-action output output-array msg)])
                  void)))
 
-    (send (output "acc") canvas)))
+    (send (output "acc") canvas))
 
 (define (add-ordered acc widget)
   (define (add-ordered ls acc)

--- a/modules/rkt/rkt-fbp/agents/gui/canvas/ellipse.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/canvas/ellipse.rkt
@@ -11,7 +11,6 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
    (define msg (recv (input "in")))
    (match msg
      [(cons 'init (vector x y width height))
@@ -30,4 +29,4 @@
      [(cons 'delete #t)
       (send (output "out") msg)]
      [else
-      (send-action output output-array (cons (class-send msg get-event-type) msg))])))
+      (send-action output output-array (cons (class-send msg get-event-type) msg))]))

--- a/modules/rkt/rkt-fbp/agents/gui/canvas/line.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/canvas/line.rkt
@@ -11,7 +11,6 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
    (define msg (recv (input "in")))
    (match msg
      [(cons 'init (vector x y end-x end-y))
@@ -39,4 +38,4 @@
      [(cons 'delete #t)
       (send (output "out") msg)]
      [else
-      (send-action output output-array msg)])))
+      (send-action output output-array msg)]))

--- a/modules/rkt/rkt-fbp/agents/gui/canvas/rectangle.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/canvas/rectangle.rkt
@@ -11,7 +11,6 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
    (define msg (recv (input "in")))
    (match msg
      [(cons 'init (vector x y width height))
@@ -30,4 +29,4 @@
      [(cons 'delete #t)
       (send (output "out") msg)]
      [else
-      (send-action output output-array (cons (class-send msg get-event-type) msg))])))
+      (send-action output output-array (cons (class-send msg get-event-type) msg))]))

--- a/modules/rkt/rkt-fbp/agents/gui/canvas/text.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/canvas/text.rkt
@@ -11,7 +11,6 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
    (define msg (recv (input "in")))
    (match msg
      [(cons 'init (vector text x y))
@@ -31,4 +30,4 @@
      [(cons 'delete #t)
       (send (output "out") msg)]
      [else
-      (send-action output output-array (cons (class-send msg get-event-type) msg))])))
+      (send-action output output-array (cons (class-send msg get-event-type) msg))]))

--- a/modules/rkt/rkt-fbp/agents/gui/check-box.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/check-box.rkt
@@ -60,8 +60,7 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg (recv (input "in")))
     (set! acc (manage acc msg input output output-array generate process-msg))
-    (send (output "acc") acc)))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/gui/choice.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/choice.rkt
@@ -68,8 +68,7 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg (recv (input "in")))
     (set! acc (manage acc msg input output output-array generate process-msg))
-    (send (output "acc") acc)))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/gui/combo-field.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/combo-field.rkt
@@ -80,8 +80,7 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg (recv (input "in")))
     (set! acc (manage acc msg input output output-array generate process-msg))
-    (send (output "acc") acc)))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/gui/frame/frame.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/frame/frame.rkt
@@ -9,7 +9,6 @@
 (define-agent
   #:input '("in") ; in port
   #:output '("out" "halt" "fvm") ; out port
-  (fun
    (define acc (try-recv (input "acc")))
    (define msg (recv (input "in")))
    (define fr (if acc
@@ -35,4 +34,4 @@
                 _))
       (void)]
      [else (display "msg: ") (displayln msg)])
-   (send (output "acc") fr)))
+   (send (output "acc") fr))

--- a/modules/rkt/rkt-fbp/agents/gui/gauge.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/gauge.rkt
@@ -65,8 +65,7 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg (recv (input "in")))
     (set! acc (manage acc msg input output output-array generate process-msg))
-    (send (output "acc") acc)))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/gui/get-file.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/get-file.rkt
@@ -7,8 +7,7 @@
 (define-agent
   #:input '("in") ; in port
   #:output '("out") ; out port
-  (fun
    (define msg (recv (input "in")))
    (define option (try-recv (input "option")))
    (define path (gui:get-file))
-   (send (output "out") (path->string path))))
+   (send (output "out") (path->string path)))

--- a/modules/rkt/rkt-fbp/agents/gui/horizontal-dragable.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/horizontal-dragable.rkt
@@ -31,7 +31,6 @@
   #:input-array '("place")
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg-in (try-recv (input "in")))
     ; Init the first time
@@ -75,7 +74,7 @@
                         [else (send-action output output-array msg)])
                  void)))
 
-    (send (output "acc") hp)))
+    (send (output "acc") hp))
 
 (define (add-ordered acc key val)
   (define (add-ordered ls acc)

--- a/modules/rkt/rkt-fbp/agents/gui/horizontal-panel.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/horizontal-panel.rkt
@@ -30,7 +30,6 @@
   #:input-array '("place")
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg-in (try-recv (input "in")))
     ; Init the first time
@@ -74,7 +73,7 @@
                         [else (send-action output output-array msg)])
                  void)))
 
-    (send (output "acc") hp)))
+    (send (output "acc") hp))
 
 (define (add-ordered acc key val)
   (define (add-ordered ls acc)

--- a/modules/rkt/rkt-fbp/agents/gui/list-box.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/list-box.rkt
@@ -65,8 +65,7 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg (recv (input "in")))
     (set! acc (manage acc msg input output output-array generate process-msg))
-    (send (output "acc") acc)))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/gui/menu-bar.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/menu-bar.rkt
@@ -18,7 +18,6 @@
   #:input-array '("place")
   #:output '("out")
   #:output-array '("out")
-  (fun
    (define acc (try-recv (input "acc")))
    (set! acc (or acc
                  (begin
@@ -58,8 +57,7 @@
        [else (send-action output output-array msg)]
        )
      )
-   (send (output "acc") acc)
-   ))
+   (send (output "acc") acc))
 
 (define (add-ordered acc key val)
   (define (add-ordered ls acc)

--- a/modules/rkt/rkt-fbp/agents/gui/menu-item.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/menu-item.rkt
@@ -45,8 +45,7 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg (recv (input "in")))
     (set! acc (manage acc msg input output output-array generate process-msg))
-    (send (output "acc") acc)))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/gui/menu.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/menu.rkt
@@ -17,7 +17,6 @@
   #:input-array '("place")
   #:output '("out")
   #:output-array '("out")
-  (fun
    (define acc (try-recv (input "acc")))
    (set! acc (or acc
                  (begin
@@ -61,8 +60,7 @@
        )
      )
 
-   (send (output "acc") acc)
-   ))
+   (send (output "acc") acc))
 
 (define (add-ordered acc key val)
   (define (add-ordered ls acc)

--- a/modules/rkt/rkt-fbp/agents/gui/message.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/message.rkt
@@ -58,8 +58,7 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg (recv (input "in")))
     (set! acc (manage acc msg input output output-array generate process-msg))
-    (send (output "acc") acc)))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/gui/pasteboard.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/pasteboard.rkt
@@ -99,7 +99,6 @@
   #:input-array '("place" "snip")
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define try-acc (try-recv (input "acc")))
 
     ; Init the first time
@@ -165,7 +164,7 @@
         [else (send-action output output-array msg)]
         ))
 
-    (send (output "acc") acc)))
+    (send (output "acc") acc))
 
 (define (add-ordered acc widget)
   (define (add-ordered ls acc)

--- a/modules/rkt/rkt-fbp/agents/gui/pasteboard.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/pasteboard.rkt
@@ -13,7 +13,7 @@
 (require/edge ${gui.widget})
 (require/edge ${gui.snip})
 
-(struct agt (place snip widget) #:prefab #:mutable)
+(struct snip-agt (place snip widget) #:prefab #:mutable)
 
 (define (my-pb% state)
   (class pasteboard% (super-new); The base class is canvas%
@@ -23,7 +23,7 @@
                               left top right bottom
                               dx dy
                               draw-caret)
-     (for ([wdg (agt-place state)])
+     (for ([wdg (snip-agt-place state)])
        ((widget-draw wdg) before? dc left top right bottom dx dy)))
 
     (define (after-select snip on?)
@@ -54,7 +54,7 @@
     ; Define overriding method to handle mouse events
     (define/override (on-event event)
       (define send? #f)
-      (for/or ([wdg (reverse (agt-place state))])
+      (for/or ([wdg (reverse (snip-agt-place state))])
         (if ((widget-box wdg)
              (class-send this get-dc)
              (class-send event get-x)
@@ -77,12 +77,12 @@
 
 (define (generate input)
   (lambda (frame)
-    (let* ([state (agt '() '() #f)]
+    (let* ([state (snip-agt '() '() #f)]
            [canvas (new (my-ed state input)
                         [parent frame]
                         [editor (new (my-pb% state))]
                                           )])
-      (set-agt-widget! state canvas)
+      (set-snip-agt-widget! state canvas)
       (send (input "acc") state))))
 
 (define (process-msg msg widget input output output-array)
@@ -112,7 +112,7 @@
     ; Input "in"
     (if msg-in
         ; TRUE : A message in the input port
-        (process-msg msg-in (agt-widget acc) input output output-array)
+        (process-msg msg-in (snip-agt-widget acc) input output output-array)
         void)
     ; Array input "place" (widget on the canvas)
     (for ([(place containee) (input-array "place")])
@@ -125,14 +125,14 @@
          ; Add it
          (add-ordered acc wdg)
          ; Redraw
-         (class-send (agt-widget acc) refresh)
+         (class-send (snip-agt-widget acc) refresh)
          ]
         [(cons 'delete #t)
-         (set-agt-place! acc
+         (set-snip-agt-place! acc
                          (filter (lambda (x)
                                    (not (eq?  place (widget-id x))))
-                                 (agt-place acc)))
-         (class-send (agt-widget acc) refresh)
+                                 (snip-agt-place acc)))
+         (class-send (snip-agt-widget acc) refresh)
          ]
         [else (send-action output output-array msg)])
       )
@@ -147,20 +147,20 @@
          ; Save in the acc, and retrieve the "before" snip
          (define before (add-ordered-snip acc wdg))
          ; Insert in pasteboard
-         (class-send (class-send (agt-widget acc) get-editor) insert
+         (class-send (class-send (snip-agt-widget acc) get-editor) insert
                      (snip-snip wdg)
                      before
                      (snip-x wdg) (snip-y wdg))
-         (class-send (agt-widget acc) refresh)]
+         (class-send (snip-agt-widget acc) refresh)]
         [(cons 'delete #t)
-         (define snp (findf (lambda (x) (eq? id-snip (snip-id x))) (agt-snip acc)))
-         (define pb (class-send (agt-widget acc) get-editor))
+         (define snp (findf (lambda (x) (eq? id-snip (snip-id x))) (snip-agt-snip acc)))
+         (define pb (class-send (snip-agt-widget acc) get-editor))
          (class-send pb delete (snip-snip snp))
-         (set-agt-snip! acc
+         (set-snip-agt-snip! acc
                         (filter (lambda (x)
                                   (not (eq? id-snip (snip-id x))))
-                                (agt-snip acc)))
-         (class-send (agt-widget acc) refresh)]
+                                (snip-agt-snip acc)))
+         (class-send (snip-agt-widget acc) refresh)]
         [else (send-action output output-array msg)]
         ))
 
@@ -179,7 +179,7 @@
             (append (reverse (cons widget acc)) ls)
             ; continue
             (add-ordered (cdr ls) (cons (car ls) acc)))]))
-  (set-agt-place! acc (add-ordered (agt-place acc) '())))
+  (set-snip-agt-place! acc (add-ordered (snip-agt-place acc) '())))
 
 (define (add-ordered-snip acc widget)
   (define before #f)
@@ -203,5 +203,5 @@
              (append (reverse (cons widget acc)) ls))
            ; continue
            (add-ordered (cdr ls) (cons (car ls) acc)))]))
-  (set-agt-snip! acc (add-ordered (agt-snip acc) '()))
+  (set-snip-agt-snip! acc (add-ordered (snip-agt-snip acc) '()))
   before)

--- a/modules/rkt/rkt-fbp/agents/gui/place-holder.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/place-holder.rkt
@@ -30,7 +30,6 @@
   #:input-array '("place")
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg-in (try-recv (input "in")))
     ; Init the first time
@@ -85,4 +84,4 @@
                         [else (send-action output output-array msg)])
                  void)))
 
-    (send (output "acc") ph)))
+    (send (output "acc") ph))

--- a/modules/rkt/rkt-fbp/agents/gui/radio-box.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/radio-box.rkt
@@ -73,8 +73,7 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg (recv (input "in")))
     (set! acc (manage acc msg input output output-array generate process-msg))
-    (send (output "acc") acc)))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/gui/slider.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/slider.rkt
@@ -67,8 +67,7 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg (recv (input "in")))
     (set! acc (manage acc msg input output output-array generate process-msg))
-    (send (output "acc") acc)))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/gui/snip/image.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/snip/image.rkt
@@ -24,7 +24,6 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
    (define msg (recv (input "in")))
    (match msg
      [(cons 'init (vector x y path))
@@ -39,4 +38,4 @@
      [(cons 'delete #t)
       (send (output "out") msg)]
      [else
-      (send-action output output-array msg)])))
+      (send-action output output-array msg)]))

--- a/modules/rkt/rkt-fbp/agents/gui/snip/pasteboard.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/snip/pasteboard.rkt
@@ -8,7 +8,7 @@
 (require/edge ${gui.widget})
 (require/edge ${gui.snip})
 
-(struct agt (place snip widget) #:prefab #:mutable)
+(struct snip-agt (place snip widget) #:prefab #:mutable)
 
 (define (my-pb% state)
   (class pasteboard% (super-new); The base class is canvas%
@@ -18,7 +18,7 @@
                               left top right bottom
                               dx dy
                               draw-caret)
-     (for ([wdg (agt-place state)])
+     (for ([wdg (snip-agt-place state)])
        ((widget-draw wdg) before? dc left top right bottom dx dy)))
 
     (define (after-select snip on?)
@@ -64,10 +64,10 @@
   #:output-array '("out")
    (define try-acc (try-recv (input "acc")))
    (define acc (or try-acc
-                   (agt '() '() #f)))
+                   (snip-agt '() '() #f)))
 
    ; input "in"
-   (define msg (if (not (agt-widget acc))
+   (define msg (if (not (snip-agt-widget acc))
                    (recv (input "in"))
                    (try-recv (input "in"))))
    (match msg
@@ -79,7 +79,7 @@
                        [editor editor]
                        [with-border? #f]))
       (class-send snp set-flags '(handles-all-mouse-events))
-      (set-agt-widget! acc snp)
+      (set-snip-agt-widget! acc snp)
       (send (output "out")
             (cons 'init (snip
                          0
@@ -102,10 +102,10 @@
         (add-ordered acc wdg)
         ]
        [(cons 'delete #t)
-        (set-agt-place! acc
+        (set-snip-agt-place! acc
                         (filter (lambda (x)
                                   (not (eq?  place (widget-id x))))
-                                (agt-place acc)))
+                                (snip-agt-place acc)))
         ]
        [else (send-action output output-array msg)]))
 
@@ -120,19 +120,19 @@
          ; Save in the acc, and retrieve the "before" snip
          (define before (add-ordered-snip acc wdg))
          ; Insert in pasteboard
-         (class-send (class-send (agt-widget acc) get-editor) insert
+         (class-send (class-send (snip-agt-widget acc) get-editor) insert
                      (snip-snip wdg)
                      before
                      (snip-x wdg) (snip-y wdg))
          ]
         [(cons 'delete #t)
-         (define snp (findf (lambda (x) (eq? id-snip (snip-id x))) (agt-snip acc)))
-         (define pb (class-send (agt-widget acc) get-editor))
+         (define snp (findf (lambda (x) (eq? id-snip (snip-id x))) (snip-agt-snip acc)))
+         (define pb (class-send (snip-agt-widget acc) get-editor))
          (class-send pb delete (snip-snip snp))
-         (set-agt-snip! acc
+         (set-snip-agt-snip! acc
                         (filter (lambda (x)
                                   (not (eq? id-snip (snip-id x))))
-                                (agt-snip acc)))
+                                (snip-agt-snip acc)))
          ]
         [else (send-action output output-array msg)]))
 
@@ -151,7 +151,7 @@
             (append (reverse (cons widget acc)) ls)
             ; continue
             (add-ordered (cdr ls) (cons (car ls) acc)))]))
-  (set-agt-place! acc (add-ordered (agt-place acc) '())))
+  (set-snip-agt-place! acc (add-ordered (snip-agt-place acc) '())))
 
 (define (add-ordered-snip acc widget)
   (define before #f)
@@ -175,5 +175,5 @@
              (append (reverse (cons widget acc)) ls))
            ; continue
            (add-ordered (cdr ls) (cons (car ls) acc)))]))
-  (set-agt-snip! acc (add-ordered (agt-snip acc) '()))
+  (set-snip-agt-snip! acc (add-ordered (snip-agt-snip acc) '()))
   before)

--- a/modules/rkt/rkt-fbp/agents/gui/snip/pasteboard.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/snip/pasteboard.rkt
@@ -62,7 +62,6 @@
   #:input-array '("place" "snip")
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
    (define try-acc (try-recv (input "acc")))
    (define acc (or try-acc
                    (agt '() '() #f)))
@@ -137,7 +136,7 @@
          ]
         [else (send-action output output-array msg)]))
 
-   (send (output "acc") acc)))
+   (send (output "acc") acc))
 
 (define (add-ordered acc widget)
   (define (add-ordered ls acc)

--- a/modules/rkt/rkt-fbp/agents/gui/snip/string.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/snip/string.rkt
@@ -24,7 +24,6 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
    (define msg (recv (input "in")))
    (match msg
      [(cons 'init (vector x y string))
@@ -39,4 +38,4 @@
      [(cons 'delete #t)
       (send (output "out") msg)]
      [else
-      (send-action output output-array msg)])))
+      (send-action output output-array msg)]))

--- a/modules/rkt/rkt-fbp/agents/gui/tab-panel.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/tab-panel.rkt
@@ -28,7 +28,6 @@
   #:input-array '("place")
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg-in (try-recv (input "in")))
     ; Init the first time
@@ -83,7 +82,7 @@
                         [else (send-action output output-array msg)])
                  void)))
 
-    (send (output "acc") ph)))
+    (send (output "acc") ph))
 
 (define (split-place place)
   (define ls (string-split place ";"))

--- a/modules/rkt/rkt-fbp/agents/gui/text-field.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/text-field.rkt
@@ -68,8 +68,7 @@
   #:input '("in") ; in port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg (recv (input "in")))
     (set! acc (manage acc msg input output output-array generate process-msg))
-    (send (output "acc") acc)))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/gui/vertical-dragable.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/vertical-dragable.rkt
@@ -31,7 +31,6 @@
   #:input-array '("place")
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg-in (try-recv (input "in")))
     ; Init the first time
@@ -75,7 +74,7 @@
                         [else (send-action output output-array msg)])
                  void)))
 
-    (send (output "acc") hp)))
+    (send (output "acc") hp))
 
 (define (add-ordered acc key val)
   (define (add-ordered ls acc)

--- a/modules/rkt/rkt-fbp/agents/gui/vertical-panel.rkt
+++ b/modules/rkt/rkt-fbp/agents/gui/vertical-panel.rkt
@@ -30,7 +30,6 @@
   #:input-array '("place")
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define acc (try-recv (input "acc")))
     (define msg-in (try-recv (input "in")))
     ; Init the first time
@@ -74,7 +73,7 @@
                         [else (send-action output output-array msg)])
                  void)))
 
-    (send (output "acc") hp)))
+    (send (output "acc") hp))
 
 (define (add-ordered acc key val)
   (define (add-ordered ls acc)

--- a/modules/rkt/rkt-fbp/agents/halter.rkt
+++ b/modules/rkt/rkt-fbp/agents/halter.rkt
@@ -4,7 +4,6 @@
 
 (define-agent
   #:input '("in") ; in port
-  (fun
    (define msg (recv (input "in")))
    (define msg2 (recv (input "in")))
-   (void)))
+   (void))

--- a/modules/rkt/rkt-fbp/agents/hyperflow/graph/in-agent.rkt
+++ b/modules/rkt/rkt-fbp/agents/hyperflow/graph/in-agent.rkt
@@ -6,8 +6,7 @@
 (define-agent
   #:input '("in") ; in array port
   #:output '("out") ; out port
-  (fun
    (define msg (recv (input "in")))
    (define path (string-split msg "fractalide/modules/rkt/rkt-fbp/"))
    (define o (g-agent "" (cadr path)))
-   (send (output "out") o)))
+   (send (output "out") o))

--- a/modules/rkt/rkt-fbp/agents/hyperflow/graph/line/model.rkt
+++ b/modules/rkt/rkt-fbp/agents/hyperflow/graph/line/model.rkt
@@ -10,7 +10,6 @@
   #:input-array '()
   #:output '("out" "line" "from" "to") ; out port
   #:output-array '("out")
-  (fun
     (define msg (recv (input "in")))
     (define acc (try-recv (input "acc")))
     (match msg
@@ -40,8 +39,7 @@
       [(cons 'choice-outport to)
        (send (output "out") (cons 'set-inport (vector (line-id acc) to)))]
       [else (send (output "out") msg)])
-    (send (output "acc") acc)
-    ))
+    (send (output "acc") acc))
 
 (define (redraw line output)
   (send (output "line") (cons 'delete #t))

--- a/modules/rkt/rkt-fbp/agents/hyperflow/graph/loader.rkt
+++ b/modules/rkt/rkt-fbp/agents/hyperflow/graph/loader.rkt
@@ -9,7 +9,6 @@
 (define-agent
   #:input '("in") ; in port
   #:output '("out" "acc") ; out port
-  (fun
    (define msg (recv (input "in")))
 
    ; Convert fractalide/graph -> g:graph
@@ -90,4 +89,4 @@
                                                   (g-edge-port-in edg)
                                                   (g-edge-selection-in edg)))))
 
-   (send (output "acc") msg)))
+   (send (output "acc") msg))

--- a/modules/rkt/rkt-fbp/agents/hyperflow/graph/mesg/model.rkt
+++ b/modules/rkt/rkt-fbp/agents/hyperflow/graph/mesg/model.rkt
@@ -11,7 +11,6 @@
   #:input-array '()
   #:output '("out" "box" "config") ; out port
   #:output-array '("out" "line-start" "line-end")
-  (fun
     (define msg (recv (input "in")))
     (define acc (try-recv (input "acc")))
     (match msg
@@ -55,5 +54,4 @@
       [(cons 'button event)
        (send (output "out") (cons 'start-mesg (mesg-id acc)))]
       [else (send (output "out") msg)])
-    (send (output "acc") acc)
-    ))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/hyperflow/graph/model.rkt
+++ b/modules/rkt/rkt-fbp/agents/hyperflow/graph/model.rkt
@@ -15,7 +15,6 @@
   #:input-array '()
   #:output '("out") ; out port
   #:output-array '()
-  (fun
     (define msg (recv (input "in")))
     (define acc (try-recv (input "acc")))
     (match msg
@@ -185,8 +184,7 @@
        (hash-set! (raw-graph-nodes acc) id (struct-copy g-edge actual [port-out port]))
        (manage-edge id actual acc input output)]
       [else (send (output "out") msg)])
-    (send (output "acc") acc)
-    ))
+    (send (output "acc") acc))
 
 (define (add-edge out port-out selec-out in port-in selec-in acc input output)
   (define edge-name (string-append "edge-" out "-" in))

--- a/modules/rkt/rkt-fbp/agents/hyperflow/graph/node/config/model.rkt
+++ b/modules/rkt/rkt-fbp/agents/hyperflow/graph/node/config/model.rkt
@@ -10,7 +10,6 @@
   #:input-array '()
   #:output '("out" "name") ; out port
   #:output-array '("out")
-  (fun
     (define msg (recv (input "in")))
     (define acc (try-recv (input "acc")))
     (match msg
@@ -21,5 +20,4 @@
       [(cons 'text-field name)
        (send (output "out") (cons 'set-name name))]
       [else (send (output "out") msg)])
-    (send (output "acc") acc)
-    ))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/hyperflow/graph/node/model.rkt
+++ b/modules/rkt/rkt-fbp/agents/hyperflow/graph/node/model.rkt
@@ -13,7 +13,6 @@
   #:input-array '()
   #:output '("out" "pb" "circle" "text" "config" "get-path") ; out port
   #:output-array '("out" "line-start" "line-end")
-  (fun
     (define msg (recv (input "in")))
     (define acc (try-recv (input "acc")))
     (match msg
@@ -74,8 +73,7 @@
        (set-node-raw! acc node)
        (refresh output output-array acc)]
       [else (send (output "out") msg)])
-    (send (output "acc") acc)
-    ))
+    (send (output "acc") acc))
 
 (define (set-type acc type input output output-array)
   ; retrieve the type path

--- a/modules/rkt/rkt-fbp/agents/hyperflow/node/exec.rkt
+++ b/modules/rkt/rkt-fbp/agents/hyperflow/node/exec.rkt
@@ -8,7 +8,6 @@
 (define-agent
   #:input '("in") ; in array port
   #:output '("out") ; out port
-  (fun
     (define msg (recv (input "in")))
     (define exec
       (let ([out (open-output-string)])
@@ -16,4 +15,4 @@
                        [current-error-port out])
           (system (string-append "racket " msg)))
         (get-output-string out)))
-    (send (output "out") exec)))
+    (send (output "out") exec))

--- a/modules/rkt/rkt-fbp/agents/hyperflow/node/model.rkt
+++ b/modules/rkt/rkt-fbp/agents/hyperflow/node/model.rkt
@@ -11,7 +11,6 @@
   #:input-array '("compute")
   #:output '("out" "code" "eval" "save") ; out port
   #:output-array '("compute")
-  (fun
     (define msg (recv (input "in")))
     (define acc (try-recv (input "acc")))
     (match msg
@@ -50,5 +49,4 @@
                   '(refresh . #t))
             ]
            [else (send (output "out") msg)])
-    (send (output "acc") acc)
-    ))
+    (send (output "acc") acc))

--- a/modules/rkt/rkt-fbp/agents/math/nand.rkt
+++ b/modules/rkt/rkt-fbp/agents/math/nand.rkt
@@ -5,7 +5,6 @@
 (define-agent
   #:input '("a" "b")
   #:output '("out")
-  (fun
    (define a (recv (input "a")))
    (define b (recv (input "b")))
-   (send (output "out") (nand a b))))
+   (send (output "out") (nand a b)))

--- a/modules/rkt/rkt-fbp/agents/mesg/action.rkt
+++ b/modules/rkt/rkt-fbp/agents/mesg/action.rkt
@@ -7,6 +7,5 @@
   #:input '("in") ; in array port
   #:output '("out") ; out port
   #:output-array '("out")
-  (fun
     (define msg (recv (input "in")))
-    (send-action output output-array msg)))
+    (send-action output output-array msg))

--- a/modules/rkt/rkt-fbp/agents/mesg/drop-action.rkt
+++ b/modules/rkt/rkt-fbp/agents/mesg/drop-action.rkt
@@ -6,6 +6,5 @@
 (define-agent
   #:input '("in") ; in array port
   #:output '("out") ; out port
-  (fun
     (define msg (recv (input "in")))
-    (send (output "out") (cdr msg))))
+    (send (output "out") (cdr msg)))

--- a/modules/rkt/rkt-fbp/agents/mesg/drop.rkt
+++ b/modules/rkt/rkt-fbp/agents/mesg/drop.rkt
@@ -4,5 +4,4 @@
 
 (define-agent
   #:input '("in") ; in array port
-  (fun
-    (recv (input "in"))))
+    (recv (input "in")))

--- a/modules/rkt/rkt-fbp/agents/mesg/put-action.rkt
+++ b/modules/rkt/rkt-fbp/agents/mesg/put-action.rkt
@@ -6,8 +6,7 @@
 (define-agent
   #:input '("in") ; in array port
   #:output '("out") ; out port
-  (fun
     (define msg (recv (input "in")))
     (define new-msg (cons (recv (input "option"))
                           msg))
-    (send (output "out") new-msg)))
+    (send (output "out") new-msg))

--- a/modules/rkt/rkt-fbp/agents/mesg/set-action.rkt
+++ b/modules/rkt/rkt-fbp/agents/mesg/set-action.rkt
@@ -6,8 +6,7 @@
 (define-agent
   #:input '("in") ; in array port
   #:output '("out") ; out port
-  (fun
     (define msg (recv (input "in")))
     (define new-msg (cons (recv (input "option"))
                           (cdr msg)))
-    (send (output "out") new-msg)))
+    (send (output "out") new-msg))

--- a/modules/rkt/rkt-fbp/agents/mesg/set-ip.rkt
+++ b/modules/rkt/rkt-fbp/agents/mesg/set-ip.rkt
@@ -6,7 +6,6 @@
 (define-agent
   #:input '("in") ; in array port
   #:output '("out") ; out port
-  (fun
     (define _ (recv (input "in")))
     (define msg (recv (input "option")))
-    (send (output "out") msg)))
+    (send (output "out") msg))

--- a/modules/rkt/rkt-fbp/agents/plumbing/cycle-transform.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/cycle-transform.rkt
@@ -5,10 +5,9 @@
 (define-agent
   #:input '("in")
   #:output '("out")
-  (fun
    (define option (recv (input "option")))
    (send (input "option") (append (cdr option) (list (car option))))
-   (send (output "out") ((car option) (recv (input "in"))))))
+   (send (output "out") ((car option) (recv (input "in")))))
 
 (module+ test
   (require rackunit)

--- a/modules/rkt/rkt-fbp/agents/plumbing/demux.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/demux.rkt
@@ -5,11 +5,10 @@
 (define-agent
   #:input '("in")
   #:output-array '("out")
-  (fun
    (define in-msg (recv (input "in")))
    (define f (or (try-recv (input "option")) list))
    (for ([msg (f in-msg)])
-        (send (hash-ref (output-array "out") (car msg)) (cdr msg)))))
+        (send (hash-ref (output-array "out") (car msg)) (cdr msg))))
 
 (module+ test
   (require rackunit)

--- a/modules/rkt/rkt-fbp/agents/plumbing/identity.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/identity.rkt
@@ -5,8 +5,7 @@
 (define-agent
   #:input '("in")
   #:output '("out")
-  (fun
-   (send (output "out") (recv (input "in")))))
+   (send (output "out") (recv (input "in"))))
 
 (module+ test
   (require rackunit)

--- a/modules/rkt/rkt-fbp/agents/plumbing/mux-demux.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/mux-demux.rkt
@@ -5,14 +5,13 @@
 (define-agent
   #:input-array '("in")
   #:output-array '("out")
-  (fun
    (define f (or (try-recv (input "option")) list))
    (for ([(selection port) (input-array "in")])
         (define in-msg (try-recv port))
         (when in-msg
               (for ([sel-msg (f (cons selection in-msg))])
                    (match-define (cons sel msg) sel-msg)
-                   (send (hash-ref (output-array "out") sel) msg))))))
+                   (send (hash-ref (output-array "out") sel) msg)))))
 
 (module+ test
   (require rackunit)

--- a/modules/rkt/rkt-fbp/agents/plumbing/mux.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/mux.rkt
@@ -5,13 +5,12 @@
 (define-agent
   #:input-array '("in")
   #:output '("out")
-  (fun
    (define f (or (try-recv (input "option")) list))
    (for ([(selection port) (input-array "in")])
         (define in-msg (try-recv port))
         (when in-msg
               (for ([msg (f (cons selection in-msg))])
-                   (send (output "out") msg))))))
+                   (send (output "out") msg)))))
 
 (module+ test
   (require rackunit)

--- a/modules/rkt/rkt-fbp/agents/plumbing/option-transform.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/option-transform.rkt
@@ -5,8 +5,7 @@
 (define-agent
   #:input '("in")
   #:output '("out")
-  (fun
-   (send (output "out") ((recv (input "option")) (recv (input "in"))))))
+   (send (output "out") ((recv (input "option")) (recv (input "in")))))
 
 (module+ test
   (require rackunit)

--- a/modules/rkt/rkt-fbp/agents/plumbing/transform-in-msgs.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/transform-in-msgs.rkt
@@ -5,9 +5,8 @@
 (define-agent
   #:input '("in")
   #:output '("out")
-  (fun
    (for ([msg ((recv (input "option")) (recv (input "in")))])
-     (send (output "out") msg))))
+     (send (output "out") msg)))
 
 (module+ test
   (require rackunit)

--- a/modules/rkt/rkt-fbp/agents/plumbing/transform-ins-msgs.rkt
+++ b/modules/rkt/rkt-fbp/agents/plumbing/transform-ins-msgs.rkt
@@ -5,13 +5,12 @@
 (define-agent
   #:input-array '("in")
   #:output '("out")
-  (fun
    (define latest-acc (or (try-recv (input "acc")) (make-hash)))
    (define acc (for/hash ([(k port) (in-hash (input-array "in"))]) (values k (or (try-recv port) (hash-ref latest-acc k #f)))))
    (when (for/and ([v (in-hash-values acc)]) v)
          (define msgs ((recv (input "option")) acc))
          (for ([msg msgs]) (send (output "out") msg)))
-   (send (output "acc") acc)))
+   (send (output "acc") acc))
 
 (module+ test
   (require rackunit)

--- a/modules/rkt/rkt-fbp/agents/test/counter/model.rkt
+++ b/modules/rkt/rkt-fbp/agents/test/counter/model.rkt
@@ -5,7 +5,6 @@
 (define-agent
   #:input '("add" "sub")
   #:output '("out")
-  (fun
     (let* ([add (try-recv (input "add"))]
            [sub (try-recv (input "sub"))]
            [try-acc (try-recv (input "acc"))]
@@ -15,4 +14,4 @@
            [add-acc (if add (+ 1 acc) acc)]
            [sub-acc (if sub (- add-acc 1) add-acc)])
       (send (output "out") (cons 'set-label (string-append "counter : " (number->string sub-acc))))
-      (send (output "acc") sub-acc))))
+      (send (output "acc") sub-acc)))

--- a/modules/rkt/rkt-fbp/agents/test/dynamic.rkt
+++ b/modules/rkt/rkt-fbp/agents/test/dynamic.rkt
@@ -10,7 +10,6 @@
   #:input '("in")
   #:output '("out")
   #:output-array '("out")
-  (fun
     (let* ([acc (try-recv (input "acc"))]
            [option (recv (input "option"))]
            [msg (recv (input "in"))])
@@ -48,4 +47,4 @@
                   ; false, do nothing
                   (void))]
              [else (send-action output output-array msg)])
-      (send (output "acc") new-acc))))
+      (send (output "acc") new-acc)))

--- a/modules/rkt/rkt-fbp/agents/test/to-display.rkt
+++ b/modules/rkt/rkt-fbp/agents/test/to-display.rkt
@@ -6,8 +6,6 @@
 (define-agent
   #:input '("in")
   #:output-array '("out")
-  (fun
     (let* ([msg (recv (input "in"))])
       (match-define (cons 'choice num) msg)
-      (send (hash-ref (output-array "out") num) (cons 'display #t))
-      )))
+      (send (hash-ref (output-array "out") num) (cons 'display #t))))

--- a/nodes/rkt/paging-jsend-get.rkt
+++ b/nodes/rkt/paging-jsend-get.rkt
@@ -60,7 +60,6 @@
 (define-agent
   #:input '("in" "http")
   #:output '("out" "http")
-  (fun
    (define (do-get-request url accept)
      (send (output "http")
            (http-get-request (url->string url) (if accept accept #"application/json")))
@@ -95,7 +94,7 @@
 
    (define request (recv (input "in")))
    (match-define (http-get-request url accept) request)
-   (do-get-request (string->url url) accept)))
+   (do-get-request (string->url url) accept))
 
 (module+ test
   (require rackunit)

--- a/nodes/rkt/paging-jsend-get/test/mock.rkt
+++ b/nodes/rkt/paging-jsend-get/test/mock.rkt
@@ -9,7 +9,6 @@
 (define-agent
   #:input '("in" "jsend")
   #:output '("out" "state")
-  (fun
    (define state (make-hash))
    (define request (recv (input "in")))
    (match-define (http-get-request url _) request)
@@ -26,4 +25,4 @@
                                                             (totalEntries . 1)))))))))
    (define jsend-response (list (recv (input "jsend")) (recv (input "jsend"))))
    (hash-set! state 'jsend-response jsend-response)
-   (send (output "state") state)))
+   (send (output "state") state))


### PR DESCRIPTION


There are two tricky things about this:

 - Adding these symbols in the caller's namespace is unhygienic, so
   Racket works hard to prevent it. The workaround that `fun` used
   with `datum->syntax` and creating the names outside the `(syntax)`
   forms is the only way.
 - The keyword arguments. To cleanly pick out the body and the keyword
   arguments, and not need `define-agent-priv`, `syntax-parse` is
   necessary.

Solution: Merge `define-agent-priv` and `fun` into new `define-agent`.

 - Remove `fun` from the codebase.
 - Remove `#:proc` as it is not used anywhere.

Closes the discussion in #217