### PR TITLE
Problem: Exception information is hidden

### DIFF
--- a/modules/rkt/rkt-fbp/agents/exception-raiser.rkt
+++ b/modules/rkt/rkt-fbp/agents/exception-raiser.rkt
@@ -1,0 +1,25 @@
+#!/usr/bin/env racket
+#lang racket
+
+(require fractalide/modules/rkt/rkt-fbp/agent)
+
+(define-agent
+  #:input '("in")
+
+  (define msg (or (try-recv (input "option")) "mistakes were made"))
+
+  (recv (input "in"))
+  (error msg))
+
+(module+ main
+  (require syntax/location)
+
+  (require fractalide/modules/rkt/rkt-fbp/graph)
+  (require fractalide/modules/rkt/rkt-fbp/def)
+  (require fractalide/modules/rkt/rkt-fbp/fvm)
+
+  (call-with-new-fvm-and-scheduler (lambda (fvm-sched sched)
+    (define path (quote-module-path ".."))
+    (define a-graph (make-graph (node "main" path)
+                                (mesg "main" "in" #t)))
+    (fvm-sched (msg-mesg "fvm" "in" (cons 'add a-graph))))))

--- a/modules/rkt/rkt-fbp/scheduler.rkt
+++ b/modules/rkt/rkt-fbp/scheduler.rkt
@@ -3,6 +3,7 @@
 (provide make-scheduler (struct-out scheduler))
 
 (require racket/async-channel)
+(require racket/exn)
 
 (require racket/match)
 (require racket/function)
@@ -220,8 +221,8 @@
         ; change is-running to true and exec
         (begin
           (thread (lambda ()
-                    (with-handlers ([exn:fail? (lambda (v) (displayln (string-append "Agent " agt-name " fails with : "))
-                                                       (displayln v))])
+                    (with-handlers ([exn:fail?
+                                    (lambda (e) (eprintf "in agent ~a:~n~a" agt-name (exn->string e)))])
                       (proc
                        ((curry get-in) agt)
                        ((curry get-out) agt)


### PR DESCRIPTION
When an agent fails, we just print the exception on the output,
without parsing it. This hides valuable information when
trouble-shooting.

Solution: Use `exn->string` to get the strack trace.

Before:

    modules/rkt/rkt-fbp/agents$ ./exception-raiser.rkt
    Agent main fails with :
    #(struct:exn:fail mistakes were made #<continuation-mark-set>)

After:

    modules/rkt/rkt-fbp/agents$ ./exception-raiser.rkt
    in agent main:
    mistakes were made
      context...:
       /home/clacke/git/fractalide/fractalide/modules/rkt/rkt-fbp/scheduler.rkt:223:18

This is still lacking information. But if we instrument the source,
we can get more:

    modules/rkt/rkt-fbp/agents$ racket -l errortrace -t ./exception-raiser.rkt
    in agent main:
    mistakes were made
      errortrace...:
       /home/clacke/git/fractalide/fractalide/modules/rkt/rkt-fbp/agents/exception-raiser.rkt:12:2: (error msg)
       /home/clacke/git/fractalide/fractalide/modules/rkt/rkt-fbp/scheduler.rkt:224:20: (with-handlers ((exn:fail? (lambda (e) (eprintf "in agent ~a:~n~a" ....)))) (proc ((curry get-in) agt) ((curry get-out) agt) ((curry get-in-array) agt) ((curry ....) agt)))
      context...:
       /home/clacke/git/fractalide/fractalide/modules/rkt/rkt-fbp/scheduler.rkt:223:18

Much better!

`raco setup` can be run with `--mode errortrace` to install this by
default. We'll have to look at what this means for performance, and if
there are any other issues.

I would have preferred to re-raise the error rather than print it,
but that seems to interfere with the scheduler. In this version,
running exception-raiser terminates. If I re-raise, it doesn't.

Probably the scheduler would have to reap its threads, but as we
wouldn't do anything with them anyway, the current way is
probably just as good.