### PR TITLE
 Problem: Loading every graph twice

### DIFF
--- a/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
@@ -66,7 +66,17 @@
   (require fractalide/modules/rkt/rkt-fbp/def)
   (require fractalide/modules/rkt/rkt-fbp/fvm)
 
+  (define stop? #f)
+
+  (command-line
+    #:program "cardano-wallet"
+    #:once-each [("--stop") "Set up the window, then immediately quit. Only useful for profiling."
+                 (set! stop? #t)]
+    #:args args (void))
+
   (call-with-new-fvm-and-scheduler (lambda (fvm-sched sched)
     (define path (quote-module-path ".."))
     (define a-graph (make-graph (node "main" path)))
-    (fvm-sched (msg-mesg "fvm" "in" (cons 'add a-graph))))))
+    (fvm-sched (msg-mesg "fvm" "in" (cons 'add a-graph)))
+    (when stop? (fvm-sched (msg-mesg "fvm" "in"
+      (cons 'add (make-graph (mesg "main-frame" "in" (cons 'close #t))))))))))

--- a/modules/rkt/rkt-fbp/agents/fvm/get-graph.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/get-graph.rkt
@@ -12,9 +12,12 @@
           [name (g-agent-name agt)]
           [type (g-agent-type agt)])
      ; retrieve the graph struct
-     (define g (load-graph type))
-     ; rename the subgraph
-     (let ([new-agent
+     (define g (load-graph type (lambda () #f)))
+     (cond
+       [(not g) (send (output "out") #f)] ; not a graph
+       [else ; rename the nodes in the subgraph
+        (let
+          ([new-agent
             (for/list ([agent (graph-agent g)])
               (struct-copy g-agent agent [name (string-append name "-" (g-agent-name agent))]))]
            [new-edge
@@ -32,4 +35,4 @@
            [new-mesg
             (for/list ([mesg (graph-mesg g)])
               (struct-copy g-mesg mesg [in (string-append name "-" (g-mesg-in mesg))]))])
-       (send (output "out") (graph new-agent new-edge new-virtual-in new-virtual-out new-mesg)))))
+        (send (output "out") (graph new-agent new-edge new-virtual-in new-virtual-out new-mesg)))])))

--- a/modules/rkt/rkt-fbp/agents/fvm/load-graph.rkt
+++ b/modules/rkt/rkt-fbp/agents/fvm/load-graph.rkt
@@ -2,7 +2,6 @@
 
 (require racket/list)
 (require fractalide/modules/rkt/rkt-fbp/agent)
-(require fractalide/modules/rkt/rkt-fbp/loader)
 (require fractalide/modules/rkt/rkt-fbp/graph)
 
 ; (-> agent graph)
@@ -19,10 +18,10 @@
         ; False -> Visit the next node
         (let* ([next (car not-visited)]
                [next (begin (send (output "ask-path") next) (recv (input "ask-path")))]
-               [is-subnet? (load-graph (g-agent-type next) (lambda () #f))])
-          (if is-subnet?
+               [maybe-subgraph (get-graph next input output)])
+          (if maybe-subgraph
               ; It's a sub-graph. Get the new graph, add the nodes in not-visited, save the virtual port and save the rest of the graph
-              (let* ([new-graph (get-graph next input output)]
+              (let* ([new-graph maybe-subgraph]
                      ; Add the agents in the not-visited list
                      [new-not-visited (append (graph-agent new-graph) (cdr not-visited))]
                      ; add the virtual port


### PR DESCRIPTION

Solution: Use the get-graph agent the first time, and keep the result.

 - Make get-graph fail gracefully on non-graphs.

No significant difference on cardano-wallet, which surprised me, but
this still feels better.