### PR TITLE
Problem: Not automatically finding 'dot'

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -34,7 +34,7 @@ pkgs {
       inherit racket2nix;
       inherit (racket2nix) buildRacketPackage;
       rustPlatform = super.recurseIntoAttrs (super.makeRustPlatform rust);
-      fractalide = self.buildRacketPackage (builtins.path {
+      fractalide = (self.buildRacketPackage (builtins.path {
         name = "fractalide";
         path = ./..;
         filter = (path: type:
@@ -46,6 +46,12 @@ pkgs {
           (null == builtins.match "[#].*[#]" basePath) &&
           (null == builtins.match ".*~" basePath)
         );
+      })).overrideAttrs (oldAttrs: {
+        buildInputs = oldAttrs.buildInputs or [] ++ [ self.makeWrapper ];
+        inherit (self) graphviz;
+        postInstall = oldAttrs.postInstall or "" + ''
+          wrapProgram $env/bin/hyperflow --prefix PATH ":" $graphviz/bin
+        '';
       });
 
       # fractalide/racket2nix#78 workaround


### PR DESCRIPTION
Solution: Add path to 'dot' to launcher wrapper.

Now you can just:

    modules/rkt/rkt-fbp$ nix-shell --pure -p  $(nix-build ../../.. -A pkgs.fractalide.env) --run hyperflow

And it will run 'dot' from the nix store without you having to keep it
on your PATH.

Closes #318