### PR TITLE
Problem: darwin: argument list limits

### DIFF
--- a/pkgs/racket2nix/default.nix
+++ b/pkgs/racket2nix/default.nix
@@ -3,8 +3,8 @@ let
   pinnedPkgs = bootPkgs.fetchFromGitHub {
     owner = "fractalide";
     repo = "racket2nix";
-    rev = "75f84d3708e1155323b0575f34b169d2f22ca369";
-    sha256 = "019ad4j19z2gwc4knam2sqi1ybwbyasr81yq8zahj2b2zk4g9ywq";
+    rev = "f44516247f57be18bf49a66d82df9b90cbcd6671";
+    sha256 = "15ixl1yaz2hq0i67yb3g0cc4in5fpzk44j56js9cqwlqykfskdgl";
   };
 in
 import pinnedPkgs


### PR DESCRIPTION
    /nix/store/jkb56ipz7yckrw7imqqfmjjjp90pvs3r-racket-minimal-7.0/bin/racket -G /nix/store/9h5c1qgxkkjj2l7jkld3ijas39sy4xyf-racket-minimal-7.0-fractalide-env/etc/racket -U -X /nix/store/9h5c1qgxkkjj2l7jkld3ijas39sy4xyf-racket-minimal-7.0-fractalide-env/share/racket/collects
    find: 'chmod': Argument list too long

Solution: Bump to fractalide/racket2nix#225 .