### PR TITLE
Problem: release.sh: Fails when nixpkgs is not where it expected

### DIFF
--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -22,18 +22,8 @@ function main() {
 
 
 function build() {
-  local nixpkgs_paths=()
-
-  for path in \
-    $HOME/.nix-defexpr/channels/nixpkgs \
-    /nix/var/nix/profiles/per-user/root/channels/nixpkgs \
-  ; do
-    [[ -e $path ]] &&
-    nixpkgs_paths+=(-I "$(readlink "$path")")
-  done
-
   nix-build --fallback --option restrict-eval true --arg isTravis true \
-    "${nixpkgs_paths[@]}" \
+    -I nixpkgs=$(nix-instantiate --eval -E 'with import <nixpkgs> {}; path') \
     --show-trace "$@" |& subfold ${!#}
 }
 


### PR DESCRIPTION
If your nixpkgs is not in root channels or your .nix-defexpr:

    error: access to path '/nix/store/jimqj08azlz09d823dn140v1bxlfrrj3-nixpkgs-19.03pre157646.f129ed25a04/nixpkgs' is forbidden in restricted mode

Solution: Don't guess where <nixpkgs> might be, ask Nix.