### PR TITLE
Problem: crates/updates.sh: Needs to be run in crates dir

### DIFF
--- a/modules/rs/crates/update.sh
+++ b/modules/rs/crates/update.sh
@@ -1,8 +1,9 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash -p cargo carnix
 
-set -e
-set -u
+set -euo pipefail
+
+cd "${BASH_SOURCE[0]%/*}"
 
 nix-build Cargo.toml.nix | xargs cat > Cargo.toml.new
 mv Cargo.toml{.new,}


### PR DESCRIPTION
Solution: Make update.sh cd to the appropriate directory.

Also set pipefail, for consistency.