### PR TITLE
 Problem: cardano-wallet: No expect dependency

### DIFF
--- a/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
+++ b/modules/rkt/rkt-fbp/agents/cardano-wallet.rkt
@@ -1,5 +1,5 @@
 #!/usr/bin/env racket
-#lang racket/base
+#lang racket
 
 (require fractalide/modules/rkt/rkt-fbp/graph)
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -48,9 +48,10 @@ pkgs {
         );
       })).overrideAttrs (oldAttrs: {
         buildInputs = oldAttrs.buildInputs or [] ++ [ self.makeWrapper ];
-        inherit (self) graphviz;
+        inherit (self) expect graphviz;
         postInstall = oldAttrs.postInstall or "" + ''
           wrapProgram $env/bin/hyperflow --prefix PATH ":" $graphviz/bin
+          wrapProgram $env/bin/cardano-wallet --prefix PATH ":" $expect/bin
         '';
       });
 


### PR DESCRIPTION


Solution: Add it.

Now if you `nix-build -A pkgs.fractalide` and run
`./result/bin/cardano-wallet` you won't need `expect` explicitly
installed on your system.

`cardano-cli` will have to wait until we have successfully nixified
it, see #356 .