### PR TITLE
Problem: raco wastes a lot of time

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -39,6 +39,7 @@ pkgs {
         path = ./..;
         filter = (path: type:
           let basePath = baseNameOf path; in
+          (null != builtins.match ((toString ./..) + "(/info.rkt|/(modules|edges|nodes)(/rkt(/.*)?)?)") path) &&
           (type != "symlink" || null == builtins.match "result.*" basePath) &&
           (null == builtins.match ".*[.]nix" basePath) &&
           (null == builtins.match "[.].*[.]swp" basePath) &&


### PR DESCRIPTION
It's examining every directory of documentation, rust code etc for
racket files to compile, and it's very slow at doing so.

Solution: Make `fractalide.src` narrower, with explicit directories.

NOTE: `builtins.path` uses its filter function differently from
`builtins.filterSource` -- a directory needs to be filtered `true` for
`path` to descend into the directory.

A `filterSource` condition could have been:

    (null != builtins.match ((toString ./..) + "(/info.rkt|/(modules|edges|nodes)/rkt/.*)") path)

... but for `path` the `/rkt/.*` needs to be optional so the parent
directory matches, and within `/rkt/.*` the `/.*` needs to be optional
so the `rkt` directory matches. That's why the slightly convoluted
`(/rkt(/.*)?)?`.

Now, on my machine the difference is not great, because it takes a
ridiculously long time anyway:

Before:

real	11m33,282s
user	0m3,544s
sys	0m0,514s

After:

real	11m22,826s
user	0m2,008s
sys	0m0,497s

One of those minutes is due to fractalide/racket2nix#241, but I think
there may also be something odd about my system. Maybe it's the /nix
on ZFS, maybe it's something else.