### PR TITLE
Fix links to documentation files

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,6 @@
 # Documentation
-* [Nodes](../nodes/README.md)
-* [Edges](../edges/README.md)
-* [Services](../services/README.md)
-* [Fractals](../fractals/README.md)
+* [Nodes](../nodes/README.adoc)
+* [Edges](../edges/README.adoc)
+* [Services](../services/README.adoc)
+* [Fractals](../fractals/README.adoc)
 * [RustFBP](https://docs.rs/rustfbp)


### PR DESCRIPTION
Change links so that they point to the actual documentation files.