### PR TITLE
Problem: rkt-tests: Fails because cantor and guiv2 require gui

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -83,8 +83,8 @@ pkgs {
         # If we allow raco test to run on anything in agents/gui it will fail because
         # requiring (gui/...) fails on headless.
 
-        find ${fractalide.env}/share/racket/pkgs/*/modules/rkt/rkt-fbp/agents \
-          '(' -name gui -prune ')' -o '(' -name '*.rkt' -print ')' |
+        find ${fractalide.env}/share/racket/pkgs/*/modules/rkt/rkt-fbp/agents -name '*.rkt' |
+          xargs grep -l 'module[+] test' |
           parallel -n 1 -j ''${NIX_BUILD_CORES:-1} bash $racoTest |
           tee $out
         exit ''${PIPESTATUS[1]}


### PR DESCRIPTION
This breaks the test runner.

Instead of adding them to the exclusion list, accept that only 10 of
our rkt files contain tests.

Solution: Test only files that declare a test submodule.

As a bonus, this drastically cuts down testing time. Racket takes a
very long time (20 s -- 30 s) just to load a file, only to find out
there are no tests. This is now done on 10 files instead of 172 files.

Grepping for 'module+ test' is not a generic way of finding tests, but
it works on our code.