### PR TITLE
Problem: rkt-tests: Our own ad-hoc testing

### DIFF
--- a/pkgs/racket2nix/default.json
+++ b/pkgs/racket2nix/default.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/fractalide/racket2nix.git",
-  "rev": "dd882f9b7e859cd5bcb936b7c3446fba45f1e220",
-  "date": "2018-12-04T16:18:57+08:00",
-  "sha256": "0nhx4677d9d9an7rnbz4436k51pwi7fajlhbnksj3qq0ybfl9s70",
+  "rev": "4c1e6bd2337d67913e977d900e3d2a067d293713",
+  "date": "2019-04-05T05:41:38+08:00",
+  "sha256": "1yhf5743v23g826bmkgw6gavpcmyigr1q1hbni4qyw3lvdx6zkva",
   "fetchSubmodules": false
 }

--- a/release.nix
+++ b/release.nix
@@ -3,7 +3,7 @@
 
 let
   genJobs = pkgs: {
-    inherit (pkgs) fractalide rkt-tests;
+    inherit (pkgs) fractalide;
     rs-tests = import ./tests;
     cardano = (import ./. { inherit pkgs; }).mods.rs.deps.cardano."0.1.0";
     rustfbp = (import ./. {}).mods.rs.deps.rustfbp."0.3.34";
@@ -16,5 +16,5 @@ in
       latest-nixpkgs = genJobs (import ./pkgs { system = "x86_64-darwin"; pkgs = import <nixpkgs>; });
     };
   } // (import <nixpkgs> {}).lib.optionalAttrs isTravis {
-    travisOrder = [ "rs-tests" "rkt-tests" ];
+    travisOrder = [ "rs-tests" "fractalide" ];
   }


### PR DESCRIPTION
Solution: Bump racket2nix, use installCheck, remove rkt-tests.

With installCheck enabled on fractalide, rkt-tests becomes redundant.