### PR TITLE
Fix spelling and grammar in README files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -80,7 +80,7 @@ Indeed it's these simple `derivations` that allow python 2.7 and 3.0 to exist si
 
 ===== Reusability
 
-Flow-based programming in our books has delivered on its promise. In our system FBP components are known as a `nodes` and they are reusable, clean and composable. It's a very nice way to program computers. Though, we've found, the larger the network of `nodes`, the more overhead required to build, manage, version, package, connect, test and distribute all these moving pieces. This really doesn't weigh well against FBP's advantages. Still, there is this beautiful reusable side that is highly advantageous! If only we could take the good parts?
+Flow-based programming in our books has delivered on its promise. In our system FBP components are known as `nodes` and they are reusable, clean and composable. It's a very nice way to program computers. Though, we've found, the larger the network of `nodes`, the more overhead required to build, manage, version, package, connect, test and distribute all these moving pieces. This really doesn't weigh well against FBP's advantages. Still, there is this beautiful reusable side that is highly advantageous! If only we could take the good parts?
 
 ===== Reproducibility + Reusability
 
@@ -106,7 +106,7 @@ It's this feature that sets us apart from Google TensorFlow and Apache-NiFi. It 
 
 The vast majority of system configuration management solutions use either the divergent or convergent model.
 
-We're going to quote Steve Traugott's excellent work vebatim.
+We're going to quote Steve Traugott's excellent work verbatim.
 
 ==== Divergent
 
@@ -159,7 +159,7 @@ A language needed to be chosen to implement Fractalide. Now as Fractalide is pri
 
 ==== Solution
 
-Rust was a perfect fit. The concept of ownership is critical in Flow-based Programming. The Flow-based scheduler is typically responsible for tracking every Information Packet (IP) as it flows through the system. Fortunately Rust excels at getting the concept of ownership right. To the point of leveraging this concept that a garbage collector is not needed. Indeed, different forms of concurrency can be layered on Rust's ownership concept. One very neat advantage Rust gives us is that we can very elegantly implement Flow-based Programming's idea of concurrency. This makes our scheduler extremely lightweight as it doesn't need to track IPs at all. Once an IP isn't owned by any component, Rust makes it wink out of existance, no harm to anyone.
+Rust was a perfect fit. The concept of ownership is critical in Flow-based Programming. The Flow-based scheduler is typically responsible for tracking every Information Packet (IP) as it flows through the system. Fortunately Rust excels at getting the concept of ownership right. To the point of leveraging this concept that a garbage collector is not needed. Indeed, different forms of concurrency can be layered on Rust's ownership concept. One very neat advantage Rust gives us is that we can very elegantly implement Flow-based Programming's idea of concurrency. This makes our scheduler extremely lightweight as it doesn't need to track IPs at all. Once an IP isn't owned by any component, Rust makes it wink out of existence, no harm to anyone.
 
 === API contracts
 
@@ -204,7 +204,7 @@ boolean : false
 * Read the link:./CONTRIBUTING.md[C4.2 (Collective Code Construction Contract)] and the https://github.com/Blockrazor/blockrazor/blob/master/DESCRIPTIVE_C4.MD[line by line explanation] of the protocol.
 * Fork this github repository under your own github account.
 * Clone _your_ fork locally on your development machine.
-* Choose _one_ problem to solve. If you aren't solving a problem that's already in the issue tracker you should describe the problem there (and your idea of the solution) first to see if anyone else has something to say about it (maybe someone is already working on a solution, or maybe you're doing somthing wrong). **If the issue is in the issue tracker, you should comment on the issue to say you're working on the solution so that other people don't work on the same thing.**
+* Choose _one_ problem to solve. If you aren't solving a problem that's already in the issue tracker you should describe the problem there (and your idea of the solution) first to see if anyone else has something to say about it (maybe someone is already working on a solution, or maybe you're doing something wrong). **If the issue is in the issue tracker, you should comment on the issue to say you're working on the solution so that other people don't work on the same thing.**
 * Add the Fractalide repository as an upstream source and pull any changes:
 [source, sh]
 ----
@@ -250,7 +250,7 @@ $ git checkout master
 ----
 
 #### Q: Can I be paid to contribute to Fractalide?
-Yes, this is sometimes possible. Your first step is to _very carefully read and understand everything above_, including the linked files, then start fixing problems and sending pull requests! If your code is amazing and brilliant but you don't understand the contribution process we cannot consider you for a paid position. Make sure you follow the project on Github so you get updates. Contact Fractalide's BDFL (Benevolent Dictator For Life): mailto:setori88@gmail.com[Stewart Mackenzie] if you've been contributing code to Fractalide and want to keep doing it but but you require financial assistance.
+Yes, this is sometimes possible. Your first step is to _very carefully read and understand everything above_, including the linked files, then start fixing problems and sending pull requests! If your code is amazing and brilliant but you don't understand the contribution process we cannot consider you for a paid position. Make sure you follow the project on Github so you get updates. Contact Fractalide's BDFL (Benevolent Dictator For Life): mailto:setori88@gmail.com[Stewart Mackenzie] if you've been contributing code to Fractalide and want to keep doing it but you require financial assistance.
 
 == Consulting and Support
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,5 @@
 # Documentation
+
 * [Nodes](../nodes/README.adoc)
 * [Edges](../edges/README.adoc)
 * [Services](../services/README.adoc)

--- a/edges/README.adoc
+++ b/edges/README.adoc
@@ -17,7 +17,7 @@ There are three phases building up to a successful `Edge` formation:
 
 Once an `edge` is formed, it becomes a bounded buffer message passing channel, which can only contain `messages` with data in the shape of whatever the Cap'n Proto schema is.
 
-So despite you seeing only Cap'n Proto schema in this directory, the concept of an `Edge` is  more profound. Hence we would prefer naming this concept after it's grandest manifestation, and in the process, the name encapsulates all of the above information. The name should also tie in with the concept of a `node` in graph theory, as such we use `nodes` and `edges` to construct `subgraphs`.
+So despite you seeing only Cap'n Proto schema in this directory, the concept of an `Edge` is  more profound. Hence we would prefer naming this concept after its grandest manifestation, and in the process, the name encapsulates all of the above information. The name should also tie in with the concept of a `node` in graph theory, as such we use `nodes` and `edges` to construct `subgraphs`.
 
 === Exposed Edge or iMsg
 
@@ -35,13 +35,13 @@ subgraph {
 }
 ----
 
-`Exposed edges` or `imsgs` kick start `agents` into action, otherwise they won't start. Due to the dataflow nature of `agents` they will politely wait for data before they start doing anything. This is the equivalent of passing the path of a data source to some executable on the command line. Without the argument the program would just sit or fail. Another way of looking at it might be a pipeline that has come to the surface to accept some form of input.
+`Exposed edges` or `imsgs` kickstart `agents` into action, otherwise they won't start. Due to the dataflow nature of `agents` they will politely wait for data before they start doing anything. This is the equivalent of passing the path of a data source to some executable on the command line. Without the argument the program would just sit or fail. Another way of looking at it might be a pipeline that has come to the surface to accept some form of input.
 
 We use the name `exposed edge` to differentiate between a `hidden edge`, but by far the most common usage is `imsg` and `edge`.
 
 === Hidden Edge or Edge
 
-`Hidden edges` are represented with this syntax `+->+` and `+=>+`, and are used to control the direction flowing data. Hence the process of programming a `subgraph` is essentially digging ditches and laying pipelines between buildings.
+`Hidden edges` are represented with this syntax `+->+` and `+=>+`, and are used to control the direction of flowing data. Hence the process of programming a `subgraph` is essentially digging ditches and laying pipelines between buildings.
 
 Examples of `hidden edges`
 
@@ -90,8 +90,8 @@ subgraph {
 == Why?
 
 * Contracts between components are critical for creating https://hintjens.gitbooks.io/social-architecture/content/chapter6.html[living systems].
-* Schema ensure we do not need to parse strangely formatted `stdin` data.
-* A `node` does one and only one thing, and the schema represents a language the `node` speaks. If you want a `node` to do something, you have to speak it's language.
+* Schemas ensure we do not need to parse strangely formatted `stdin` data.
+* A `node` does one and only one thing, and the schema represents a language the `node` speaks. If you want a `node` to do something, you have to speak its language.
 
 == Who?
 
@@ -99,7 +99,7 @@ Typically `subgraph` developers will be interested in `hidden and exposed edges`
 
 == Where?
 
-The `edges` directory is where all the schema go:
+The `edges` directory is where all the schemas go:
 
 [source]
 ----
@@ -130,7 +130,7 @@ The `{ edge, edges }:` lambda passes in two arguments, the `edge` builder and `e
 The `edge` building function accepts these arguments:
 
 * The `src` attribute is used to derive an `Edge` name based on location in the directory hierarchy.
-* The `edges` attribute resolve transitive dependencies and ensures your `agent` has all the needed files to type check.
+* The `edges` attribute resolves transitive dependencies and ensures your `agent` has all the needed files to type check.
 * a https://capnproto.org[Cap 'n Proto] `schema`. This is the heart of the contract, this is where you may create potentially complex deep hierarchies of structured data. Please read more about the https://capnproto.org/language.html[schema language].
 
 [source, nix, subs="none"]
@@ -154,15 +154,15 @@ edge {
 
 Please use CamelCase for `struct` and `enum` names. The naming should reflect this manner:
 
-* if the schema is in folder `/edges/maths/boolean` then the `struct` should have name `MathsBoolean`.
-* if the schema is in `fractal` `/edges/net/http/response` then the `struct` should have name `NetHttpResponse`.
+* if the schema is in the folder `/edges/maths/boolean` then the `struct` should have the name `MathsBoolean`.
+* if the schema is in th folder `/edges/net/http/response` then the `struct` should have the name `NetHttpResponse`.
 
 The same naming applies for Cap'n Proto `enums` and `interfaces`. It's crucial this naming is adopted.
 
 === One struct per Fractalide schema
 
-We prefer composition of schema, and the schema must have fully qualified struct names.
-Hence, this is example shouldn't be used:
+Each schema should have one struct with a fully qualified name.
+Hence, this example should not be used:
 
 [source, nix, subs="none"]
 ----
@@ -205,7 +205,7 @@ The `Date` name can collide!
 
 Schema are pulled into ``agent``'s scope just before compile time, now we are unable to predict what combinations will happen.
 So if we have two schema that have `struct Date ...` then a name collision will take place.
-Therefore to avoid this scenario please put `struct Date ...` into it's own schema and import it via this mechanism.
+Therefore to avoid this scenario please put `struct Date ...` into its own schema and import it via this mechanism.
 
 === Cap'n Proto import
 

--- a/fractals/README.adoc
+++ b/fractals/README.adoc
@@ -17,7 +17,7 @@ Anyone making high quality, documented nodes, subgraphs and edges may plug into 
 
 == Where?
 
-Each `fractal` needs to have it's own hierarchical folder. For example, HTTP would be placed in the `fractalide/fractals/net/http` folder.
+Each `fractal` needs to have its own hierarchical folder. For example, HTTP would be placed in the `fractalide/fractals/net/http` folder.
 
 == How?
 
@@ -106,7 +106,7 @@ You'd use a https://github.com/fractalide/fractalide/blob/2312ac77fbb09f7a6cb2d2
 Incremental Builds speed up the development process, so that one doesn't have to compile the entire crate from scratch each time you make a change to the source code.
 
 Fractalide expands the nix-build system for incremental builds. The Incremental Builds only work when debug is enabled. They also need the path to a cache folder.
-The cache folder can be created from an old result by the `buildCache.sh` script. Per default the cache folder is saved in the `/tmp` folder of your system. Incremental Builds permit you to compile a crate without having to recompiled the crate dependency tree.
+The cache folder can be created from an old result by the `buildCache.sh` script. Per default the cache folder is saved in the `/tmp` folder of your system. Incremental Builds permit you to compile a crate without having to recompile the crate dependency tree.
 
 Here is an example how you can build with the Incremental Build System:
 

--- a/nodes/README.adoc
+++ b/nodes/README.adoc
@@ -46,7 +46,7 @@ See the above `default.nix` files? Those are `Subgraphs` and they hide the entir
 
 === How?
 
-The `Subgraph` `default.nix` requires you make decisions about two types of dependencies.
+The `Subgraph` `default.nix` requires you to make decisions about two types of dependencies.
 
 * What `Nodes` are needed?
 * What `Edges` are needed?

--- a/nodes/idr/README.adoc
+++ b/nodes/idr/README.adoc
@@ -9,7 +9,7 @@ Executable `Subgraphs` are defined as a network of `Agents`, which exchange type
 
 Functions in a programming language should be placed in a content addressable store, this is the horizontal plane. The vertical plane should be constructed using unique addresses into this content addressable store, critically each address should solve a single problem, and may do so by referencing multiple other unique addresses in the content addressable store. Users must not have knowledge of these unique addresses but a translation process should occur from a human readable name to a universally unique address. Read http://erlang.org/pipermail/erlang-questions/2011-May/058768.html[more] about the problem.
 
-Nix gives us the content addressable store which allows for `reproducibility`, and these `agents` give us `reusablility`. The combination is particularly potent form of programming.
+Nix gives us the content addressable store which allows for `reproducibility`, and these `agents` give us `reusability`. The combination is particularly potent form of programming.
 
 Once you have the above, you have truly reusable and reproducible functions. Fractalide nodes are just this, and it makes the below so much easier to achieve:
 

--- a/nodes/rs/README.adoc
+++ b/nodes/rs/README.adoc
@@ -9,7 +9,7 @@ Executable `Subgraphs` are defined as a network of `Agents`, which exchange type
 
 Functions in a programming language should be placed in a content addressable store, this is the horizontal plane. The vertical plane should be constructed using unique addresses into this content addressable store, critically each address should solve a single problem, and may do so by referencing multiple other unique addresses in the content addressable store. Users must not have knowledge of these unique addresses but a translation process should occur from a human readable name to a universally unique address. Read http://erlang.org/pipermail/erlang-questions/2011-May/058768.html[more] about the problem.
 
-Nix gives us the content addressable store which allows for `reproducibility`, and these `agents` give us `reusablility`. The combination is particularly potent form of programming.
+Nix gives us the content addressable store which allows for `reproducibility`, and these `agents` give us `reusability`. The combination is a particularly potent form of programming.
 
 Once you have the above, you have truly reusable and reproducible functions. Fractalide nodes are just this, and it makes the below so much easier to achieve:
 
@@ -61,7 +61,7 @@ An `Agent` consists of two parts:
 
 === The `agent` Nix function.
 
-The `agent` function in the `default.nix` requires you make decisions about three types of dependencies.
+The `agent` function in the `default.nix` requires you to make decisions about three types of dependencies.
 
 * What `edges` are needed?
 * What `mods` from https://crates.io[crates.io] are needed?

--- a/services/README.adoc
+++ b/services/README.adoc
@@ -8,7 +8,7 @@
 == Why?
 
 `Services` allow programmers to collaborate and distill common configurable patterns that solve general problems.
-Essentially a `service` in this context is no different from a top level `subgraph`, albeit the interface has been `nix`'ified. The `nix` interface is required because this is where `nixos` takes over and declaratively handles conguent configuration management. It does things like sets up dependencies such as database and other services that might need to be run for the `subgraph` to operate properly. This layer of software has been well tested by the `nix` community and ties in with every other service created by the `nixos` community.
+Essentially a `service` in this context is no different from a top level `subgraph`, albeit the interface has been `nix`'ified. The `nix` interface is required because this is where `nixos` takes over and declaratively handles congruent configuration management. It does things like set up dependencies such as databases and other services that might need to be run for the `subgraph` to operate properly. This layer of software has been well tested by the `nix` community and ties in with every other service created by the `nixos` community.
 
 This abstraction allows you to pull in legacy services, plug a Cap'n Proto functionality and start talking to Fractalide services.
 


### PR DESCRIPTION
This is an effort to fix (improve for clarity and accuracy) spelling and grammar (and some white space) in README files across the repository.